### PR TITLE
Fix for LiteralField model throwing exceptions instead of validation errors

### DIFF
--- a/sempyro/rdf_model.py
+++ b/sempyro/rdf_model.py
@@ -113,9 +113,10 @@ class LiteralField(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def validate(cls, data: Dict) -> Dict[str, Any]:
-        if data.get("datatype") and data.get("language"):
-            raise ValueError("A Literal can only have one of 'language' or 'datatype', "
-                             "per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal")
+        if isinstance(data, dict):
+            if data.get("datatype") and data.get("language"):
+                raise ValueError("A Literal can only have one of 'language' or 'datatype', "
+                                "per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal")
         return data
 
     @field_validator("datatype", mode="before")


### PR DESCRIPTION
Big quality of life fix!

Error before:
```
  File "/Users/markjanse/Development/xnatdcat/src/img2catalog/xnat_parser.py", line 100, in xnat_to_DCATDataset
    project_dataset = HRIDataset(**dataset_dict)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/markjanse/mambaforge/envs/xnat/lib/python3.11/site-packages/pydantic/main.py", line 164, in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
  File "/Users/markjanse/mambaforge/envs/xnat/lib/python3.11/site-packages/sempyro/rdf_model.py", line 116, in validate
    if data.get("datatype") and data.get("language"):
       ^^^^^^^^
AttributeError: 'list' object has no attribute 'get'
```

Error after:
```
  File "/Users/markjanse/Development/xnatdcat/src/img2catalog/xnat_parser.py", line 100, in xnat_to_DCATDataset
    project_dataset = HRIDataset(**dataset_dict)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/markjanse/mambaforge/envs/xnat/lib/python3.11/site-packages/pydantic/main.py", line 164, in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
pydantic_core._pydantic_core.ValidationError: 2 validation errors for HRIDataset
issued
  Field required [type=missing, input_value={'title': ['WORC'], 'desc...http://example.com/'))]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.5/v/missing
modified
  Field required [type=missing, input_value={'title': ['WORC'], 'desc...http://example.com/'))]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.5/v/missing
```