### PR TITLE
Fix rdf type of HRI dataset identifier

### DIFF
--- a/models/hri_dcat/HRIDataService.json
+++ b/models/hri_dcat/HRIDataService.json
@@ -1210,7 +1210,7 @@
           ],
           "description": "A unique identifier of the resource being described or cataloged. HRI mandatory",
           "rdf_term": "http://purl.org/dc/terms/identifier",
-          "rdf_type": "xsd:string",
+          "rdf_type": "rdfs_literal",
           "title": "Identifier"
         },
         "is_referenced_by": {

--- a/models/hri_dcat/HRIDataService.yaml
+++ b/models/hri_dcat/HRIDataService.yaml
@@ -1088,7 +1088,7 @@ $defs:
         description: A unique identifier of the resource being described or cataloged.
           HRI mandatory
         rdf_term: http://purl.org/dc/terms/identifier
-        rdf_type: xsd:string
+        rdf_type: rdfs_literal
         title: Identifier
       is_referenced_by:
         default:

--- a/models/hri_dcat/HRIDataset.json
+++ b/models/hri_dcat/HRIDataset.json
@@ -1379,7 +1379,7 @@
       ],
       "description": "A unique identifier of the resource being described or cataloged. HRI mandatory",
       "rdf_term": "http://purl.org/dc/terms/identifier",
-      "rdf_type": "xsd:string",
+      "rdf_type": "rdfs_literal",
       "title": "Identifier"
     },
     "is_referenced_by": {

--- a/models/hri_dcat/HRIDataset.yaml
+++ b/models/hri_dcat/HRIDataset.yaml
@@ -1249,7 +1249,7 @@ properties:
     description: A unique identifier of the resource being described or cataloged.
       HRI mandatory
     rdf_term: http://purl.org/dc/terms/identifier
-    rdf_type: xsd:string
+    rdf_type: rdfs_literal
     title: Identifier
   is_referenced_by:
     default:

--- a/models/hri_dcat/HRIDistribution.json
+++ b/models/hri_dcat/HRIDistribution.json
@@ -1768,7 +1768,7 @@
           ],
           "description": "A unique identifier of the resource being described or cataloged. HRI mandatory",
           "rdf_term": "http://purl.org/dc/terms/identifier",
-          "rdf_type": "xsd:string",
+          "rdf_type": "rdfs_literal",
           "title": "Identifier"
         },
         "is_referenced_by": {

--- a/models/hri_dcat/HRIDistribution.yaml
+++ b/models/hri_dcat/HRIDistribution.yaml
@@ -1534,7 +1534,7 @@ $defs:
         description: A unique identifier of the resource being described or cataloged.
           HRI mandatory
         rdf_term: http://purl.org/dc/terms/identifier
-        rdf_type: xsd:string
+        rdf_type: rdfs_literal
         title: Identifier
       is_referenced_by:
         default:

--- a/sempyro/hri_dcat/hri_dataset.py
+++ b/sempyro/hri_dcat/hri_dataset.py
@@ -62,7 +62,7 @@ class HRIDataset(DCATDataset):
     identifier: Union[str, LiteralField] = Field(
         description="A unique identifier of the resource being described or cataloged. HRI mandatory",
         rdf_term=DCTERMS.identifier,
-        rdf_type="xsd:string"
+        rdf_type="rdfs_literal"
     )
     modified: Union[str, date, AwareDatetime, NaiveDatetime] = Field(
         description="Most recent date on which the resource was changed, updated or modified. HRI mandatory",


### PR DESCRIPTION
This PR changes the rdf_type of hri_dcat Dataset Identifier field to rdfs_literal. It was xsd:string for some time, but as DCAT and DCAT-AP require it to be rdfs:literal it was changed back in the metadata model. This PR reflects that change.