### PR TITLE
Make license not mandatory in HRI dataset

### DIFF
--- a/models/hri_dcat/HRIDataService.json
+++ b/models/hri_dcat/HRIDataService.json
@@ -1252,7 +1252,7 @@
         },
         "license": {
           "default": null,
-          "description": "A legal document under which the resource is made available.",
+          "description": "A legal document under which the resource is made available. HRI recommended",
           "format": "uri",
           "minLength": 1,
           "rdf_term": "http://purl.org/dc/terms/license",

--- a/models/hri_dcat/HRIDataService.json
+++ b/models/hri_dcat/HRIDataService.json
@@ -1251,6 +1251,7 @@
           "type": "array"
         },
         "license": {
+          "default": null,
           "description": "A legal document under which the resource is made available.",
           "format": "uri",
           "minLength": 1,
@@ -1698,7 +1699,6 @@
         "creator",
         "description",
         "identifier",
-        "license",
         "publisher",
         "theme",
         "title",

--- a/models/hri_dcat/HRIDataService.yaml
+++ b/models/hri_dcat/HRIDataService.yaml
@@ -1126,6 +1126,7 @@ $defs:
       license:
         default:
         description: A legal document under which the resource is made available.
+          HRI recommended
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/license

--- a/models/hri_dcat/HRIDataService.yaml
+++ b/models/hri_dcat/HRIDataService.yaml
@@ -1124,6 +1124,7 @@ $defs:
         title: Landing Page
         type: array
       license:
+        default:
         description: A legal document under which the resource is made available.
         format: uri
         minLength: 1
@@ -1477,7 +1478,6 @@ $defs:
     - creator
     - description
     - identifier
-    - license
     - publisher
     - theme
     - title

--- a/models/hri_dcat/HRIDataset.json
+++ b/models/hri_dcat/HRIDataset.json
@@ -1420,6 +1420,7 @@
       "type": "array"
     },
     "license": {
+      "default": null,
       "description": "A legal document under which the resource is made available.",
       "format": "uri",
       "minLength": 1,
@@ -1867,7 +1868,6 @@
     "creator",
     "description",
     "identifier",
-    "license",
     "publisher",
     "theme",
     "title",

--- a/models/hri_dcat/HRIDataset.json
+++ b/models/hri_dcat/HRIDataset.json
@@ -1421,7 +1421,7 @@
     },
     "license": {
       "default": null,
-      "description": "A legal document under which the resource is made available.",
+      "description": "A legal document under which the resource is made available. HRI recommended",
       "format": "uri",
       "minLength": 1,
       "rdf_term": "http://purl.org/dc/terms/license",

--- a/models/hri_dcat/HRIDataset.yaml
+++ b/models/hri_dcat/HRIDataset.yaml
@@ -1285,6 +1285,7 @@ properties:
     title: Landing Page
     type: array
   license:
+    default:
     description: A legal document under which the resource is made available.
     format: uri
     minLength: 1
@@ -1634,7 +1635,6 @@ required:
 - creator
 - description
 - identifier
-- license
 - publisher
 - theme
 - title

--- a/models/hri_dcat/HRIDataset.yaml
+++ b/models/hri_dcat/HRIDataset.yaml
@@ -1286,7 +1286,8 @@ properties:
     type: array
   license:
     default:
-    description: A legal document under which the resource is made available.
+    description: A legal document under which the resource is made available. HRI
+      recommended
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/license

--- a/models/hri_dcat/HRIDistribution.json
+++ b/models/hri_dcat/HRIDistribution.json
@@ -1810,7 +1810,7 @@
         },
         "license": {
           "default": null,
-          "description": "A legal document under which the resource is made available.",
+          "description": "A legal document under which the resource is made available. HRI recommended",
           "format": "uri",
           "minLength": 1,
           "rdf_term": "http://purl.org/dc/terms/license",

--- a/models/hri_dcat/HRIDistribution.json
+++ b/models/hri_dcat/HRIDistribution.json
@@ -1809,6 +1809,7 @@
           "type": "array"
         },
         "license": {
+          "default": null,
           "description": "A legal document under which the resource is made available.",
           "format": "uri",
           "minLength": 1,
@@ -2256,7 +2257,6 @@
         "creator",
         "description",
         "identifier",
-        "license",
         "publisher",
         "theme",
         "title",

--- a/models/hri_dcat/HRIDistribution.yaml
+++ b/models/hri_dcat/HRIDistribution.yaml
@@ -1572,6 +1572,7 @@ $defs:
       license:
         default:
         description: A legal document under which the resource is made available.
+          HRI recommended
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/license

--- a/models/hri_dcat/HRIDistribution.yaml
+++ b/models/hri_dcat/HRIDistribution.yaml
@@ -1570,6 +1570,7 @@ $defs:
         title: Landing Page
         type: array
       license:
+        default:
         description: A legal document under which the resource is made available.
         format: uri
         minLength: 1
@@ -1923,7 +1924,6 @@ $defs:
     - creator
     - description
     - identifier
-    - license
     - publisher
     - theme
     - title

--- a/sempyro/hri_dcat/hri_dataset.py
+++ b/sempyro/hri_dcat/hri_dataset.py
@@ -90,6 +90,7 @@ class HRIDataset(DCATDataset):
         rdf_term=DCTERMS.type,
         rdf_type="uri")
     license: AnyHttpUrl = Field(
+        default=None,
         description="A legal document under which the resource is made available.",
         rdf_term=DCTERMS.license,
         rdf_type="uri"

--- a/sempyro/hri_dcat/hri_dataset.py
+++ b/sempyro/hri_dcat/hri_dataset.py
@@ -91,7 +91,7 @@ class HRIDataset(DCATDataset):
         rdf_type="uri")
     license: AnyHttpUrl = Field(
         default=None,
-        description="A legal document under which the resource is made available.",
+        description="A legal document under which the resource is made available. HRI recommended",
         rdf_term=DCTERMS.license,
         rdf_type="uri"
     )


### PR DESCRIPTION
License will be moved to Distribution in v2 and removed from Dataset. To ease this migration, we make SeMPyRO conform to the SHACLs which already have License as an optional property.