### PR TITLE
Feature/refactor mail validator

### DIFF
--- a/__tests__/test_utils.py
+++ b/__tests__/test_utils.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic_core import Url, PydanticCustomError
+
+from sempyro.utils.validator_functions import convert_to_mailto, validate_convert_email
+
+@pytest.mark.parametrize("email", ["mailto:exampleemail@domain.com",
+                                   "mailto://exampleemail@domain.com",
+                                   "exampleemail@domain.com",
+                                   "mailto:http://exampleemail@domain.com"
+                                   ])
+def test_convert_to_mailto(email):
+    calculated = convert_to_mailto(email)
+    expected = Url("mailto:exampleemail@domain.com")
+    assert calculated == expected
+
+
+@pytest.mark.parametrize("email", ["my:email@gmail.com",
+                                   "myemailgmail.com",
+                                   "mailto:emailgmail.com",
+                                   "http://email@gmail.com",
+                                   ])
+def test_email_validation(email):
+    with pytest.raises(PydanticCustomError):
+        _ = validate_convert_email(email)


### PR DESCRIPTION
Since PR #42 we now use the same email validation functions in vCard:Kind and foaf:Agent, so this is refactored in this PR. 

Along with refactoring I also added tests for these functions separately. They are also tested through the tests for the vCard:Kind and foaf:Agent models themselves. It can be decided if they are superfluous at a later time; at the moment I think it is good to have a double-check in the testing suite.