### PR TITLE
docs: Rewrites Usage_example_FDP.ipynb to use fairclient

### DIFF
--- a/docs/Usage_example_FDP.ipynb
+++ b/docs/Usage_example_FDP.ipynb
@@ -105,9 +105,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fdpAPIconnector.fdpclient import FDPClient\n",
+    "from fairclient.fdpclient import FDPClient\n",
     "\n",
-    "fdpclient = FDPClient(fdp_base, username, password)"
+    "fdpclient = FDPClient(base_url=fdp_base, username=username, password=password)"
    ]
   },
   {
@@ -258,11 +258,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "catalog_fdp_id = fdpclient.create(type=\"catalog\", data=fdp_catalog_record)\n",
-    "fdpclient.update(\n",
-    "    type=\"catalog\", subtype=\"meta/state\", id=catalog_fdp_id, data='{\"current\": \"PUBLISHED\"}', format=\"json-ld\"\n",
-    ")\n",
-    "print(catalog_fdp_id)"
+    "catalog_fdp_url = fdpclient.create_and_publish(resource_type=\"catalog\", metadata=fdp_catalog_record)\n",
+    "print(catalog_fdp_url)"
    ]
   },
   {
@@ -384,7 +381,7 @@
     "        title=[LiteralField(value=record[\"name\"])],\n",
     "        description=[LiteralField(value=record[\"description\"])],\n",
     "        identifier=record[\"id\"],\n",
-    "        is_part_of=[f\"{fdp_base}/catalog/{catalog_fdp_id}\"],\n",
+    "        is_part_of=[f\"{catalog_fdp_url}\"],\n",
     "        creator=[record[\"author_id\"]],\n",
     "        release_date=record[\"issued\"],\n",
     "        publisher=[Agent(name=[record[\"publisher_name\"]], identifier=record[\"publisher_id\"])],\n",
@@ -395,10 +392,7 @@
     "    dataset_subject = URIRef(f\"http://example.com/dataset_{record['id'][0]}\")\n",
     "    dataset_graph = dataset.to_graph(dataset_subject)\n",
     "    print(dataset_graph.serialize())\n",
-    "    dataset_fdp_id = fdpclient.create(type=\"dataset\", data=dataset_graph)\n",
-    "    fdpclient.update(\n",
-    "        type=\"dataset\", subtype=\"meta/state\", id=dataset_fdp_id, data='{\"current\": \"PUBLISHED\"}', format=\"json-ld\"\n",
-    "    )"
+    "    dataset_fdp_id = fdpclient.create_and_publish(resource_type=\"dataset\", metadata=dataset_graph)\n"
    ]
   },
   {


### PR DESCRIPTION
Inspired by pull request #28, I rewrote the Usage_example_FDP.ipynb to use fairclient instead of the fdpAPIconnector package. In a next release of fairclient and SeMPyRO we can then more easily implement error handling.