### PR TITLE
feat: add v2 recommended fields for dataservice

### DIFF
--- a/models/hri_dcat/HRICatalog.json
+++ b/models/hri_dcat/HRICatalog.json
@@ -2068,7 +2068,7 @@
         },
         "creator": {
           "default": null,
-          "description": "The entity responsible for producing the resource. Resources of type foaf:Agent are recommended as values for this property.",
+          "description": "An entity responsible for making the resource.",
           "items": {
             "anyOf": [
               {
@@ -2077,10 +2077,7 @@
                 "type": "string"
               },
               {
-                "$ref": "#/$defs/VCard"
-              },
-              {
-                "$ref": "#/$defs/Agent"
+                "$ref": "#/$defs/HRIAgent"
               }
             ]
           },
@@ -2213,21 +2210,17 @@
           "type": "array"
         },
         "rights": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LiteralField"
-            },
-            {
-              "format": "uri",
-              "minLength": 1,
-              "type": "string"
-            }
-          ],
           "default": null,
-          "description": "Information about rights held in and over the distribution. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided.",
+          "description": "Information about rights held in and over the resource.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
           "rdf_term": "http://purl.org/dc/terms/rights",
           "rdf_type": "uri",
-          "title": "Rights"
+          "title": "Rights",
+          "type": "array"
         },
         "qualified_relation": {
           "default": null,
@@ -2482,6 +2475,78 @@
           "rdf_term": "http://www.w3.org/ns/dcat#servesDataset",
           "rdf_type": "uri",
           "title": "Serves Dataset",
+          "type": "array"
+        },
+        "applicable_legislation": {
+          "default": null,
+          "description": "The legislation that is applicable to this resource.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://data.europa.eu/r5r/applicableLegislation",
+          "rdf_type": "uri",
+          "title": "Applicable Legislation",
+          "type": "array"
+        },
+        "application_profile": {
+          "default": null,
+          "description": "An established standard to which the described resource conforms.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://purl.org/dc/terms/conformsTo",
+          "rdf_type": "uri",
+          "title": "Application Profile",
+          "type": "array"
+        },
+        "format": {
+          "default": null,
+          "description": "The file format, physical medium, or dimensions of the resource.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://purl.org/dc/terms/format",
+          "rdf_type": "uri",
+          "title": "Format",
+          "type": "array"
+        },
+        "hvd_category": {
+          "default": null,
+          "description": "A data category defined in the High Value Dataset Implementing Regulation.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://data.europa.eu/r5r/hvdCategory",
+          "rdf_type": "uri",
+          "title": "Hvd Category",
+          "type": "array"
+        },
+        "other_identifier": {
+          "default": null,
+          "description": "Links a resource to an adms:Identifier class.",
+          "items": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/Identifier"
+              }
+            ]
+          },
+          "rdf_term": "http://www.w3.org/ns/adms#identifier",
+          "rdf_type": "uri",
+          "title": "Other Identifier",
           "type": "array"
         }
       },
@@ -3162,6 +3227,49 @@
         "formatted_name"
       ],
       "title": "HRIVCard",
+      "type": "object"
+    },
+    "Identifier": {
+      "$IRI": "http://www.w3.org/ns/adms#Identifier",
+      "$namespace": "http://www.w3.org/ns/adms#",
+      "$ontology": "http://www.w3.org/TR/vocab-adms/",
+      "$prefix": "adms",
+      "additionalProperties": false,
+      "properties": {
+        "notation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/LiteralField"
+            }
+          ],
+          "description": "A string that is an identifier in the context of the identifier scheme referenced by its datatype.",
+          "rdf_term": "http://www.w3.org/2004/02/skos/core#notation",
+          "rdf_type": "rdfs_literal",
+          "title": "Notation"
+        },
+        "schema_agency": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/LiteralField"
+            }
+          ],
+          "default": null,
+          "description": "The name of the agency that issued the identifier.",
+          "rdf_term": "http://www.w3.org/ns/adms#schemaAgency",
+          "rdf_type": "rdfs_literal",
+          "title": "Schema Agency"
+        }
+      },
+      "required": [
+        "notation"
+      ],
+      "title": "Identifier",
       "type": "object"
     },
     "LiteralField": {

--- a/models/hri_dcat/HRICatalog.yaml
+++ b/models/hri_dcat/HRICatalog.yaml
@@ -1782,15 +1782,13 @@ $defs:
         title: Contact Point
       creator:
         default:
-        description: The entity responsible for producing the resource. Resources
-          of type foaf:Agent are recommended as values for this property.
+        description: An entity responsible for making the resource.
         items:
           anyOf:
           - format: uri
             minLength: 1
             type: string
-          - $ref: '#/$defs/VCard'
-          - $ref: '#/$defs/Agent'
+          - $ref: '#/$defs/HRIAgent'
         rdf_term: http://purl.org/dc/terms/creator
         rdf_type: uri
         title: Creator
@@ -1900,18 +1898,16 @@ $defs:
         title: Relation
         type: array
       rights:
-        anyOf:
-        - $ref: '#/$defs/LiteralField'
-        - format: uri
+        default:
+        description: Information about rights held in and over the resource.
+        items:
+          format: uri
           minLength: 1
           type: string
-        default:
-        description: Information about rights held in and over the distribution. Recommended
-          practice is to refer to a rights statement with a URI. If this is not possible
-          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
+        type: array
       qualified_relation:
         default:
         description: Link to a description of a relationship with another resource
@@ -2122,6 +2118,64 @@ $defs:
         rdf_term: http://www.w3.org/ns/dcat#servesDataset
         rdf_type: uri
         title: Serves Dataset
+        type: array
+      applicable_legislation:
+        default:
+        description: The legislation that is applicable to this resource.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://data.europa.eu/r5r/applicableLegislation
+        rdf_type: uri
+        title: Applicable Legislation
+        type: array
+      application_profile:
+        default:
+        description: An established standard to which the described resource conforms.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://purl.org/dc/terms/conformsTo
+        rdf_type: uri
+        title: Application Profile
+        type: array
+      format:
+        default:
+        description: The file format, physical medium, or dimensions of the resource.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://purl.org/dc/terms/format
+        rdf_type: uri
+        title: Format
+        type: array
+      hvd_category:
+        default:
+        description: A data category defined in the High Value Dataset Implementing
+          Regulation.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://data.europa.eu/r5r/hvdCategory
+        rdf_type: uri
+        title: Hvd Category
+        type: array
+      other_identifier:
+        default:
+        description: Links a resource to an adms:Identifier class.
+        items:
+          anyOf:
+          - format: uri
+            minLength: 1
+            type: string
+          - $ref: '#/$defs/Identifier'
+        rdf_term: http://www.w3.org/ns/adms#identifier
+        rdf_type: uri
+        title: Other Identifier
         type: array
     required:
     - access_rights
@@ -2660,6 +2714,35 @@ $defs:
     - hasEmail
     - formatted_name
     title: HRIVCard
+    type: object
+  Identifier:
+    $IRI: http://www.w3.org/ns/adms#Identifier
+    $namespace: http://www.w3.org/ns/adms#
+    $ontology: http://www.w3.org/TR/vocab-adms/
+    $prefix: adms
+    additionalProperties: false
+    properties:
+      notation:
+        anyOf:
+        - type: string
+        - $ref: '#/$defs/LiteralField'
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
+        rdf_term: http://www.w3.org/2004/02/skos/core#notation
+        rdf_type: rdfs_literal
+        title: Notation
+      schema_agency:
+        anyOf:
+        - type: string
+        - $ref: '#/$defs/LiteralField'
+        default:
+        description: The name of the agency that issued the identifier.
+        rdf_term: http://www.w3.org/ns/adms#schemaAgency
+        rdf_type: rdfs_literal
+        title: Schema Agency
+    required:
+    - notation
+    title: Identifier
     type: object
   LiteralField:
     description: "Model to handle literal fields\nAttributes\n----------\ndatatype

--- a/models/hri_dcat/HRIDataService.json
+++ b/models/hri_dcat/HRIDataService.json
@@ -215,75 +215,6 @@
       "title": "Activity",
       "type": "object"
     },
-    "Agent": {
-      "$IRI": "http://xmlns.com/foaf/0.1/Agent",
-      "$namespace": "http://xmlns.com/foaf/0.1/",
-      "$ontology": "http://xmlns.com/foaf/spec/",
-      "$prefix": "foaf",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "description": "A name of the agent",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/$defs/LiteralField"
-              }
-            ]
-          },
-          "rdf_term": "http://xmlns.com/foaf/0.1/name",
-          "rdf_type": "rdfs_literal",
-          "title": "Name",
-          "type": "array"
-        },
-        "identifier": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/$defs/LiteralField"
-            }
-          ],
-          "description": "A unique identifier of the agent.",
-          "rdf_term": "http://purl.org/dc/terms/identifier",
-          "rdf_type": "rdfs_literal",
-          "title": "Identifier"
-        },
-        "mbox": {
-          "default": null,
-          "description": "A personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox.",
-          "items": {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
-          },
-          "rdf_term": "http://xmlns.com/foaf/0.1/mbox",
-          "rdf_type": "uri",
-          "title": "Mbox",
-          "type": "array"
-        },
-        "homepage": {
-          "default": null,
-          "description": "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact.",
-          "format": "uri",
-          "minLength": 1,
-          "rdf_term": "http://xmlns.com/foaf/0.1/homepage",
-          "rdf_type": "uri",
-          "title": "Homepage",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "identifier"
-      ],
-      "title": "Agent",
-      "type": "object"
-    },
     "Association": {
       "$IRI": "http://www.w3.org/ns/prov#Association",
       "$namespace": "http://www.w3.org/ns/prov#",
@@ -1444,6 +1375,49 @@
       "title": "HRIVCard",
       "type": "object"
     },
+    "Identifier": {
+      "$IRI": "http://www.w3.org/ns/adms#Identifier",
+      "$namespace": "http://www.w3.org/ns/adms#",
+      "$ontology": "http://www.w3.org/TR/vocab-adms/",
+      "$prefix": "adms",
+      "additionalProperties": false,
+      "properties": {
+        "notation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/LiteralField"
+            }
+          ],
+          "description": "A string that is an identifier in the context of the identifier scheme referenced by its datatype.",
+          "rdf_term": "http://www.w3.org/2004/02/skos/core#notation",
+          "rdf_type": "rdfs_literal",
+          "title": "Notation"
+        },
+        "schema_agency": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/LiteralField"
+            }
+          ],
+          "default": null,
+          "description": "The name of the agency that issued the identifier.",
+          "rdf_term": "http://www.w3.org/ns/adms#schemaAgency",
+          "rdf_type": "rdfs_literal",
+          "title": "Schema Agency"
+        }
+      },
+      "required": [
+        "notation"
+      ],
+      "title": "Identifier",
+      "type": "object"
+    },
     "LiteralField": {
       "description": "Model to handle literal fields\nAttributes\n----------\ndatatype : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date' see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html, and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\nvalue : str\n    literal value\neither datatype or language, or none of these two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal",
       "properties": {
@@ -1986,59 +1960,6 @@
       ],
       "title": "TimePosition",
       "type": "object"
-    },
-    "VCard": {
-      "$IRI": "http://www.w3.org/2006/vcard/ns#Kind",
-      "$namespace": "http://www.w3.org/2006/vcard/ns#",
-      "$ontology": "https://www.w3.org/TR/vcard-rdf/",
-      "$prefix": "v",
-      "additionalProperties": false,
-      "description": "The vCard class is equivalent to the new Kind class, which is the parent for the four explicit types\nof vCards (Individual, Organization, Location, Group)",
-      "properties": {
-        "hasEmail": {
-          "default": null,
-          "description": "The email address as a mailto URI",
-          "items": {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
-          },
-          "rdf_term": "http://www.w3.org/2006/vcard/ns#hasEmail",
-          "rdf_type": "uri",
-          "title": "Hasemail",
-          "type": "array"
-        },
-        "formatted_name": {
-          "default": null,
-          "description": "The full name of the object (as a single string). This is the only mandatory property.",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/$defs/LiteralField"
-              }
-            ]
-          },
-          "rdf_term": "http://www.w3.org/2006/vcard/ns#fn",
-          "rdf_type": "rdfs_literal",
-          "title": "Formatted Name",
-          "type": "array"
-        },
-        "hasUID": {
-          "default": null,
-          "description": "A unique identifier for the object",
-          "format": "uri",
-          "minLength": 1,
-          "rdf_term": "http://www.w3.org/2006/vcard/ns#hasUID",
-          "rdf_type": "uri",
-          "title": "Hasuid",
-          "type": "string"
-        }
-      },
-      "title": "VCard",
-      "type": "object"
     }
   },
   "$namespace": "http://www.w3.org/ns/dcat#",
@@ -2081,7 +2002,7 @@
     },
     "creator": {
       "default": null,
-      "description": "The entity responsible for producing the resource. Resources of type foaf:Agent are recommended as values for this property.",
+      "description": "An entity responsible for making the resource.",
       "items": {
         "anyOf": [
           {
@@ -2090,10 +2011,7 @@
             "type": "string"
           },
           {
-            "$ref": "#/$defs/VCard"
-          },
-          {
-            "$ref": "#/$defs/Agent"
+            "$ref": "#/$defs/HRIAgent"
           }
         ]
       },
@@ -2226,21 +2144,17 @@
       "type": "array"
     },
     "rights": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/LiteralField"
-        },
-        {
-          "format": "uri",
-          "minLength": 1,
-          "type": "string"
-        }
-      ],
       "default": null,
-      "description": "Information about rights held in and over the distribution. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided.",
+      "description": "Information about rights held in and over the resource.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
       "rdf_term": "http://purl.org/dc/terms/rights",
       "rdf_type": "uri",
-      "title": "Rights"
+      "title": "Rights",
+      "type": "array"
     },
     "qualified_relation": {
       "default": null,
@@ -2495,6 +2409,78 @@
       "rdf_term": "http://www.w3.org/ns/dcat#servesDataset",
       "rdf_type": "uri",
       "title": "Serves Dataset",
+      "type": "array"
+    },
+    "applicable_legislation": {
+      "default": null,
+      "description": "The legislation that is applicable to this resource.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
+      "rdf_term": "http://data.europa.eu/r5r/applicableLegislation",
+      "rdf_type": "uri",
+      "title": "Applicable Legislation",
+      "type": "array"
+    },
+    "application_profile": {
+      "default": null,
+      "description": "An established standard to which the described resource conforms.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
+      "rdf_term": "http://purl.org/dc/terms/conformsTo",
+      "rdf_type": "uri",
+      "title": "Application Profile",
+      "type": "array"
+    },
+    "format": {
+      "default": null,
+      "description": "The file format, physical medium, or dimensions of the resource.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
+      "rdf_term": "http://purl.org/dc/terms/format",
+      "rdf_type": "uri",
+      "title": "Format",
+      "type": "array"
+    },
+    "hvd_category": {
+      "default": null,
+      "description": "A data category defined in the High Value Dataset Implementing Regulation.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
+      "rdf_term": "http://data.europa.eu/r5r/hvdCategory",
+      "rdf_type": "uri",
+      "title": "Hvd Category",
+      "type": "array"
+    },
+    "other_identifier": {
+      "default": null,
+      "description": "Links a resource to an adms:Identifier class.",
+      "items": {
+        "anyOf": [
+          {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "$ref": "#/$defs/Identifier"
+          }
+        ]
+      },
+      "rdf_term": "http://www.w3.org/ns/adms#identifier",
+      "rdf_type": "uri",
+      "title": "Other Identifier",
       "type": "array"
     }
   },

--- a/models/hri_dcat/HRIDataService.yaml
+++ b/models/hri_dcat/HRIDataService.yaml
@@ -232,58 +232,6 @@ $defs:
         type: string
     title: Activity
     type: object
-  Agent:
-    $IRI: http://xmlns.com/foaf/0.1/Agent
-    $namespace: http://xmlns.com/foaf/0.1/
-    $ontology: http://xmlns.com/foaf/spec/
-    $prefix: foaf
-    additionalProperties: false
-    properties:
-      name:
-        description: A name of the agent
-        items:
-          anyOf:
-          - type: string
-          - $ref: '#/$defs/LiteralField'
-        rdf_term: http://xmlns.com/foaf/0.1/name
-        rdf_type: rdfs_literal
-        title: Name
-        type: array
-      identifier:
-        anyOf:
-        - type: string
-        - $ref: '#/$defs/LiteralField'
-        description: A unique identifier of the agent.
-        rdf_term: http://purl.org/dc/terms/identifier
-        rdf_type: rdfs_literal
-        title: Identifier
-      mbox:
-        default:
-        description: A personal mailbox, ie. an Internet mailbox associated with exactly
-          one owner, the first owner of this mailbox.
-        items:
-          format: uri
-          minLength: 1
-          type: string
-        rdf_term: http://xmlns.com/foaf/0.1/mbox
-        rdf_type: uri
-        title: Mbox
-        type: array
-      homepage:
-        default:
-        description: A webpage that either allows to make contact (i.e. a webform)
-          or the information contains how to get into contact.
-        format: uri
-        minLength: 1
-        rdf_term: http://xmlns.com/foaf/0.1/homepage
-        rdf_type: uri
-        title: Homepage
-        type: string
-    required:
-    - name
-    - identifier
-    title: Agent
-    type: object
   Association:
     $IRI: http://www.w3.org/ns/prov#Association
     $namespace: http://www.w3.org/ns/prov#
@@ -1281,6 +1229,35 @@ $defs:
     - formatted_name
     title: HRIVCard
     type: object
+  Identifier:
+    $IRI: http://www.w3.org/ns/adms#Identifier
+    $namespace: http://www.w3.org/ns/adms#
+    $ontology: http://www.w3.org/TR/vocab-adms/
+    $prefix: adms
+    additionalProperties: false
+    properties:
+      notation:
+        anyOf:
+        - type: string
+        - $ref: '#/$defs/LiteralField'
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
+        rdf_term: http://www.w3.org/2004/02/skos/core#notation
+        rdf_type: rdfs_literal
+        title: Notation
+      schema_agency:
+        anyOf:
+        - type: string
+        - $ref: '#/$defs/LiteralField'
+        default:
+        description: The name of the agency that issued the identifier.
+        rdf_term: http://www.w3.org/ns/adms#schemaAgency
+        rdf_type: rdfs_literal
+        title: Schema Agency
+    required:
+    - notation
+    title: Identifier
+    type: object
   LiteralField:
     description: "Model to handle literal fields\nAttributes\n----------\ndatatype
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
@@ -1762,50 +1739,6 @@ $defs:
     - hasTRS
     title: TimePosition
     type: object
-  VCard:
-    $IRI: http://www.w3.org/2006/vcard/ns#Kind
-    $namespace: http://www.w3.org/2006/vcard/ns#
-    $ontology: https://www.w3.org/TR/vcard-rdf/
-    $prefix: v
-    additionalProperties: false
-    description: "The vCard class is equivalent to the new Kind class, which is the
-      parent for the four explicit types\nof vCards (Individual, Organization, Location,
-      Group)"
-    properties:
-      hasEmail:
-        default:
-        description: The email address as a mailto URI
-        items:
-          format: uri
-          minLength: 1
-          type: string
-        rdf_term: http://www.w3.org/2006/vcard/ns#hasEmail
-        rdf_type: uri
-        title: Hasemail
-        type: array
-      formatted_name:
-        default:
-        description: The full name of the object (as a single string). This is the
-          only mandatory property.
-        items:
-          anyOf:
-          - type: string
-          - $ref: '#/$defs/LiteralField'
-        rdf_term: http://www.w3.org/2006/vcard/ns#fn
-        rdf_type: rdfs_literal
-        title: Formatted Name
-        type: array
-      hasUID:
-        default:
-        description: A unique identifier for the object
-        format: uri
-        minLength: 1
-        rdf_term: http://www.w3.org/2006/vcard/ns#hasUID
-        rdf_type: uri
-        title: Hasuid
-        type: string
-    title: VCard
-    type: object
 $namespace: http://www.w3.org/ns/dcat#
 $ontology: https://www.w3.org/TR/vocab-dcat-3/
 $prefix: dcat
@@ -1840,15 +1773,13 @@ properties:
     title: Contact Point
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of type
-      foaf:Agent are recommended as values for this property.
+    description: An entity responsible for making the resource.
     items:
       anyOf:
       - format: uri
         minLength: 1
         type: string
-      - $ref: '#/$defs/VCard'
-      - $ref: '#/$defs/Agent'
+      - $ref: '#/$defs/HRIAgent'
     rdf_term: http://purl.org/dc/terms/creator
     rdf_type: uri
     title: Creator
@@ -1957,18 +1888,16 @@ properties:
     title: Relation
     type: array
   rights:
-    anyOf:
-    - $ref: '#/$defs/LiteralField'
-    - format: uri
+    default:
+    description: Information about rights held in and over the resource.
+    items:
+      format: uri
       minLength: 1
       type: string
-    default:
-    description: Information about rights held in and over the distribution. Recommended
-      practice is to refer to a rights statement with a URI. If this is not possible
-      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
+    type: array
   qualified_relation:
     default:
     description: Link to a description of a relationship with another resource
@@ -2177,6 +2106,63 @@ properties:
     rdf_term: http://www.w3.org/ns/dcat#servesDataset
     rdf_type: uri
     title: Serves Dataset
+    type: array
+  applicable_legislation:
+    default:
+    description: The legislation that is applicable to this resource.
+    items:
+      format: uri
+      minLength: 1
+      type: string
+    rdf_term: http://data.europa.eu/r5r/applicableLegislation
+    rdf_type: uri
+    title: Applicable Legislation
+    type: array
+  application_profile:
+    default:
+    description: An established standard to which the described resource conforms.
+    items:
+      format: uri
+      minLength: 1
+      type: string
+    rdf_term: http://purl.org/dc/terms/conformsTo
+    rdf_type: uri
+    title: Application Profile
+    type: array
+  format:
+    default:
+    description: The file format, physical medium, or dimensions of the resource.
+    items:
+      format: uri
+      minLength: 1
+      type: string
+    rdf_term: http://purl.org/dc/terms/format
+    rdf_type: uri
+    title: Format
+    type: array
+  hvd_category:
+    default:
+    description: A data category defined in the High Value Dataset Implementing Regulation.
+    items:
+      format: uri
+      minLength: 1
+      type: string
+    rdf_term: http://data.europa.eu/r5r/hvdCategory
+    rdf_type: uri
+    title: Hvd Category
+    type: array
+  other_identifier:
+    default:
+    description: Links a resource to an adms:Identifier class.
+    items:
+      anyOf:
+      - format: uri
+        minLength: 1
+        type: string
+      - $ref: '#/$defs/Identifier'
+    rdf_term: http://www.w3.org/ns/adms#identifier
+    rdf_type: uri
+    title: Other Identifier
     type: array
 required:
 - access_rights

--- a/models/hri_dcat/HRIDistribution.json
+++ b/models/hri_dcat/HRIDistribution.json
@@ -215,75 +215,6 @@
       "title": "Activity",
       "type": "object"
     },
-    "Agent": {
-      "$IRI": "http://xmlns.com/foaf/0.1/Agent",
-      "$namespace": "http://xmlns.com/foaf/0.1/",
-      "$ontology": "http://xmlns.com/foaf/spec/",
-      "$prefix": "foaf",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "description": "A name of the agent",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/$defs/LiteralField"
-              }
-            ]
-          },
-          "rdf_term": "http://xmlns.com/foaf/0.1/name",
-          "rdf_type": "rdfs_literal",
-          "title": "Name",
-          "type": "array"
-        },
-        "identifier": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/$defs/LiteralField"
-            }
-          ],
-          "description": "A unique identifier of the agent.",
-          "rdf_term": "http://purl.org/dc/terms/identifier",
-          "rdf_type": "rdfs_literal",
-          "title": "Identifier"
-        },
-        "mbox": {
-          "default": null,
-          "description": "A personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox.",
-          "items": {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
-          },
-          "rdf_term": "http://xmlns.com/foaf/0.1/mbox",
-          "rdf_type": "uri",
-          "title": "Mbox",
-          "type": "array"
-        },
-        "homepage": {
-          "default": null,
-          "description": "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact.",
-          "format": "uri",
-          "minLength": 1,
-          "rdf_term": "http://xmlns.com/foaf/0.1/homepage",
-          "rdf_type": "uri",
-          "title": "Homepage",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "identifier"
-      ],
-      "title": "Agent",
-      "type": "object"
-    },
     "Association": {
       "$IRI": "http://www.w3.org/ns/prov#Association",
       "$namespace": "http://www.w3.org/ns/prov#",
@@ -861,7 +792,7 @@
         },
         "creator": {
           "default": null,
-          "description": "The entity responsible for producing the resource. Resources of type foaf:Agent are recommended as values for this property.",
+          "description": "An entity responsible for making the resource.",
           "items": {
             "anyOf": [
               {
@@ -870,10 +801,7 @@
                 "type": "string"
               },
               {
-                "$ref": "#/$defs/VCard"
-              },
-              {
-                "$ref": "#/$defs/Agent"
+                "$ref": "#/$defs/HRIAgent"
               }
             ]
           },
@@ -1006,21 +934,17 @@
           "type": "array"
         },
         "rights": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LiteralField"
-            },
-            {
-              "format": "uri",
-              "minLength": 1,
-              "type": "string"
-            }
-          ],
           "default": null,
-          "description": "Information about rights held in and over the distribution. Recommended practice is to refer to a rights statement with a URI. If this is not possible or feasible, a literal value (name, label, or short text) may be provided.",
+          "description": "Information about rights held in and over the resource.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
           "rdf_term": "http://purl.org/dc/terms/rights",
           "rdf_type": "uri",
-          "title": "Rights"
+          "title": "Rights",
+          "type": "array"
         },
         "qualified_relation": {
           "default": null,
@@ -1275,6 +1199,78 @@
           "rdf_term": "http://www.w3.org/ns/dcat#servesDataset",
           "rdf_type": "uri",
           "title": "Serves Dataset",
+          "type": "array"
+        },
+        "applicable_legislation": {
+          "default": null,
+          "description": "The legislation that is applicable to this resource.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://data.europa.eu/r5r/applicableLegislation",
+          "rdf_type": "uri",
+          "title": "Applicable Legislation",
+          "type": "array"
+        },
+        "application_profile": {
+          "default": null,
+          "description": "An established standard to which the described resource conforms.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://purl.org/dc/terms/conformsTo",
+          "rdf_type": "uri",
+          "title": "Application Profile",
+          "type": "array"
+        },
+        "format": {
+          "default": null,
+          "description": "The file format, physical medium, or dimensions of the resource.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://purl.org/dc/terms/format",
+          "rdf_type": "uri",
+          "title": "Format",
+          "type": "array"
+        },
+        "hvd_category": {
+          "default": null,
+          "description": "A data category defined in the High Value Dataset Implementing Regulation.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://data.europa.eu/r5r/hvdCategory",
+          "rdf_type": "uri",
+          "title": "Hvd Category",
+          "type": "array"
+        },
+        "other_identifier": {
+          "default": null,
+          "description": "Links a resource to an adms:Identifier class.",
+          "items": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/Identifier"
+              }
+            ]
+          },
+          "rdf_term": "http://www.w3.org/ns/adms#identifier",
+          "rdf_type": "uri",
+          "title": "Other Identifier",
           "type": "array"
         }
       },
@@ -1957,6 +1953,49 @@
       "title": "HRIVCard",
       "type": "object"
     },
+    "Identifier": {
+      "$IRI": "http://www.w3.org/ns/adms#Identifier",
+      "$namespace": "http://www.w3.org/ns/adms#",
+      "$ontology": "http://www.w3.org/TR/vocab-adms/",
+      "$prefix": "adms",
+      "additionalProperties": false,
+      "properties": {
+        "notation": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/LiteralField"
+            }
+          ],
+          "description": "A string that is an identifier in the context of the identifier scheme referenced by its datatype.",
+          "rdf_term": "http://www.w3.org/2004/02/skos/core#notation",
+          "rdf_type": "rdfs_literal",
+          "title": "Notation"
+        },
+        "schema_agency": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/LiteralField"
+            }
+          ],
+          "default": null,
+          "description": "The name of the agency that issued the identifier.",
+          "rdf_term": "http://www.w3.org/ns/adms#schemaAgency",
+          "rdf_type": "rdfs_literal",
+          "title": "Schema Agency"
+        }
+      },
+      "required": [
+        "notation"
+      ],
+      "title": "Identifier",
+      "type": "object"
+    },
     "LiteralField": {
       "description": "Model to handle literal fields\nAttributes\n----------\ndatatype : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date' see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html, and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\nvalue : str\n    literal value\neither datatype or language, or none of these two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal",
       "properties": {
@@ -2498,59 +2537,6 @@
         "hasTRS"
       ],
       "title": "TimePosition",
-      "type": "object"
-    },
-    "VCard": {
-      "$IRI": "http://www.w3.org/2006/vcard/ns#Kind",
-      "$namespace": "http://www.w3.org/2006/vcard/ns#",
-      "$ontology": "https://www.w3.org/TR/vcard-rdf/",
-      "$prefix": "v",
-      "additionalProperties": false,
-      "description": "The vCard class is equivalent to the new Kind class, which is the parent for the four explicit types\nof vCards (Individual, Organization, Location, Group)",
-      "properties": {
-        "hasEmail": {
-          "default": null,
-          "description": "The email address as a mailto URI",
-          "items": {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
-          },
-          "rdf_term": "http://www.w3.org/2006/vcard/ns#hasEmail",
-          "rdf_type": "uri",
-          "title": "Hasemail",
-          "type": "array"
-        },
-        "formatted_name": {
-          "default": null,
-          "description": "The full name of the object (as a single string). This is the only mandatory property.",
-          "items": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "$ref": "#/$defs/LiteralField"
-              }
-            ]
-          },
-          "rdf_term": "http://www.w3.org/2006/vcard/ns#fn",
-          "rdf_type": "rdfs_literal",
-          "title": "Formatted Name",
-          "type": "array"
-        },
-        "hasUID": {
-          "default": null,
-          "description": "A unique identifier for the object",
-          "format": "uri",
-          "minLength": 1,
-          "rdf_term": "http://www.w3.org/2006/vcard/ns#hasUID",
-          "rdf_type": "uri",
-          "title": "Hasuid",
-          "type": "string"
-        }
-      },
-      "title": "VCard",
       "type": "object"
     }
   },

--- a/models/hri_dcat/HRIDistribution.yaml
+++ b/models/hri_dcat/HRIDistribution.yaml
@@ -232,58 +232,6 @@ $defs:
         type: string
     title: Activity
     type: object
-  Agent:
-    $IRI: http://xmlns.com/foaf/0.1/Agent
-    $namespace: http://xmlns.com/foaf/0.1/
-    $ontology: http://xmlns.com/foaf/spec/
-    $prefix: foaf
-    additionalProperties: false
-    properties:
-      name:
-        description: A name of the agent
-        items:
-          anyOf:
-          - type: string
-          - $ref: '#/$defs/LiteralField'
-        rdf_term: http://xmlns.com/foaf/0.1/name
-        rdf_type: rdfs_literal
-        title: Name
-        type: array
-      identifier:
-        anyOf:
-        - type: string
-        - $ref: '#/$defs/LiteralField'
-        description: A unique identifier of the agent.
-        rdf_term: http://purl.org/dc/terms/identifier
-        rdf_type: rdfs_literal
-        title: Identifier
-      mbox:
-        default:
-        description: A personal mailbox, ie. an Internet mailbox associated with exactly
-          one owner, the first owner of this mailbox.
-        items:
-          format: uri
-          minLength: 1
-          type: string
-        rdf_term: http://xmlns.com/foaf/0.1/mbox
-        rdf_type: uri
-        title: Mbox
-        type: array
-      homepage:
-        default:
-        description: A webpage that either allows to make contact (i.e. a webform)
-          or the information contains how to get into contact.
-        format: uri
-        minLength: 1
-        rdf_term: http://xmlns.com/foaf/0.1/homepage
-        rdf_type: uri
-        title: Homepage
-        type: string
-    required:
-    - name
-    - identifier
-    title: Agent
-    type: object
   Association:
     $IRI: http://www.w3.org/ns/prov#Association
     $namespace: http://www.w3.org/ns/prov#
@@ -825,15 +773,13 @@ $defs:
         title: Contact Point
       creator:
         default:
-        description: The entity responsible for producing the resource. Resources
-          of type foaf:Agent are recommended as values for this property.
+        description: An entity responsible for making the resource.
         items:
           anyOf:
           - format: uri
             minLength: 1
             type: string
-          - $ref: '#/$defs/VCard'
-          - $ref: '#/$defs/Agent'
+          - $ref: '#/$defs/HRIAgent'
         rdf_term: http://purl.org/dc/terms/creator
         rdf_type: uri
         title: Creator
@@ -943,18 +889,16 @@ $defs:
         title: Relation
         type: array
       rights:
-        anyOf:
-        - $ref: '#/$defs/LiteralField'
-        - format: uri
+        default:
+        description: Information about rights held in and over the resource.
+        items:
+          format: uri
           minLength: 1
           type: string
-        default:
-        description: Information about rights held in and over the distribution. Recommended
-          practice is to refer to a rights statement with a URI. If this is not possible
-          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
+        type: array
       qualified_relation:
         default:
         description: Link to a description of a relationship with another resource
@@ -1165,6 +1109,64 @@ $defs:
         rdf_term: http://www.w3.org/ns/dcat#servesDataset
         rdf_type: uri
         title: Serves Dataset
+        type: array
+      applicable_legislation:
+        default:
+        description: The legislation that is applicable to this resource.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://data.europa.eu/r5r/applicableLegislation
+        rdf_type: uri
+        title: Applicable Legislation
+        type: array
+      application_profile:
+        default:
+        description: An established standard to which the described resource conforms.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://purl.org/dc/terms/conformsTo
+        rdf_type: uri
+        title: Application Profile
+        type: array
+      format:
+        default:
+        description: The file format, physical medium, or dimensions of the resource.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://purl.org/dc/terms/format
+        rdf_type: uri
+        title: Format
+        type: array
+      hvd_category:
+        default:
+        description: A data category defined in the High Value Dataset Implementing
+          Regulation.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://data.europa.eu/r5r/hvdCategory
+        rdf_type: uri
+        title: Hvd Category
+        type: array
+      other_identifier:
+        default:
+        description: Links a resource to an adms:Identifier class.
+        items:
+          anyOf:
+          - format: uri
+            minLength: 1
+            type: string
+          - $ref: '#/$defs/Identifier'
+        rdf_term: http://www.w3.org/ns/adms#identifier
+        rdf_type: uri
+        title: Other Identifier
         type: array
     required:
     - access_rights
@@ -1704,6 +1706,35 @@ $defs:
     - formatted_name
     title: HRIVCard
     type: object
+  Identifier:
+    $IRI: http://www.w3.org/ns/adms#Identifier
+    $namespace: http://www.w3.org/ns/adms#
+    $ontology: http://www.w3.org/TR/vocab-adms/
+    $prefix: adms
+    additionalProperties: false
+    properties:
+      notation:
+        anyOf:
+        - type: string
+        - $ref: '#/$defs/LiteralField'
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
+        rdf_term: http://www.w3.org/2004/02/skos/core#notation
+        rdf_type: rdfs_literal
+        title: Notation
+      schema_agency:
+        anyOf:
+        - type: string
+        - $ref: '#/$defs/LiteralField'
+        default:
+        description: The name of the agency that issued the identifier.
+        rdf_term: http://www.w3.org/ns/adms#schemaAgency
+        rdf_type: rdfs_literal
+        title: Schema Agency
+    required:
+    - notation
+    title: Identifier
+    type: object
   LiteralField:
     description: "Model to handle literal fields\nAttributes\n----------\ndatatype
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
@@ -2184,50 +2215,6 @@ $defs:
     required:
     - hasTRS
     title: TimePosition
-    type: object
-  VCard:
-    $IRI: http://www.w3.org/2006/vcard/ns#Kind
-    $namespace: http://www.w3.org/2006/vcard/ns#
-    $ontology: https://www.w3.org/TR/vcard-rdf/
-    $prefix: v
-    additionalProperties: false
-    description: "The vCard class is equivalent to the new Kind class, which is the
-      parent for the four explicit types\nof vCards (Individual, Organization, Location,
-      Group)"
-    properties:
-      hasEmail:
-        default:
-        description: The email address as a mailto URI
-        items:
-          format: uri
-          minLength: 1
-          type: string
-        rdf_term: http://www.w3.org/2006/vcard/ns#hasEmail
-        rdf_type: uri
-        title: Hasemail
-        type: array
-      formatted_name:
-        default:
-        description: The full name of the object (as a single string). This is the
-          only mandatory property.
-        items:
-          anyOf:
-          - type: string
-          - $ref: '#/$defs/LiteralField'
-        rdf_term: http://www.w3.org/2006/vcard/ns#fn
-        rdf_type: rdfs_literal
-        title: Formatted Name
-        type: array
-      hasUID:
-        default:
-        description: A unique identifier for the object
-        format: uri
-        minLength: 1
-        rdf_term: http://www.w3.org/2006/vcard/ns#hasUID
-        rdf_type: uri
-        title: Hasuid
-        type: string
-    title: VCard
     type: object
 $namespace: http://www.w3.org/ns/dcat#
 $ontology:

--- a/sempyro/adms/__init__.py
+++ b/sempyro/adms/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Stichting Health-RI
+# Copyright 2025 Stichting Health-RI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,30 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.metadata import version
-
-from .rdf_model import LiteralField, RDFModel
-from .utils import validator_functions
-
-__version__ = version("sempyro")
+from .identifier import Identifier
 
 __all__ = (
-    "LiteralField",
-    "RDFModel",
-    "adms",
-    "dcat",
-    "foaf",
-    "geo",
-    "hri_dcat",
-    "namespaces",
-    "odrl",
-    "prov",
-    "spdx",
-    "time",
-    "vcard",
-    "validator_functions"
-    )
-
-
-def __dir__() -> "list[str]":
-    return list(__all__)
+    "Identifier"
+)

--- a/sempyro/adms/identifier.py
+++ b/sempyro/adms/identifier.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Stichting Health-RI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from typing import Union
+
+from pydantic import ConfigDict, Field
+from rdflib.namespace import SKOS
+
+from sempyro import LiteralField, RDFModel
+from sempyro.namespaces import ADMS
+
+class Identifier(RDFModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "$ontology": "http://www.w3.org/TR/vocab-adms/",
+            "$namespace": str(ADMS),
+            "$IRI": ADMS.Identifier,
+            "$prefix": "adms"
+        }
+    )
+
+    notation: Union[str, LiteralField] = Field(
+        description="A string that is an identifier in the context of the identifier scheme referenced by its datatype.",
+        json_schema_extra={
+            "rdf_term": SKOS.notation,
+            "rdf_type": "rdfs_literal"
+        }
+    )
+
+    schema_agency: Union[str, LiteralField] = Field(
+        default=None,
+        description="The name of the agency that issued the identifier.",
+        json_schema_extra={
+            "rdf_term": ADMS.schemaAgency,
+            "rdf_type": "rdfs_literal"
+        }
+    )
+
+
+if __name__ == "__main__":
+    json_models_folder = Path(Path(__file__).parents[2].resolve(), "models", "adms")
+    Identifier.save_schema_to_file(path=Path(json_models_folder, "Identifier.json"), file_format="json")
+    Identifier.save_schema_to_file(path=Path(json_models_folder, "Identifier.yaml"), file_format="yaml")

--- a/sempyro/hri_dcat/hri_data_service.py
+++ b/sempyro/hri_dcat/hri_data_service.py
@@ -23,7 +23,9 @@ from sempyro.dcat import DCATDataService, DCATResource, AccessRights
 from sempyro.hri_dcat.hri_dataset import HRIDataset
 from sempyro.hri_dcat.hri_agent import HRIAgent
 from sempyro.hri_dcat.hri_vcard import HRIVCard
+from sempyro.adms.identifier import Identifier
 from sempyro.hri_dcat.vocabularies import GeonovumLicences, DatasetTheme
+from sempyro.namespaces import DCATAPv3, ADMS
 from sempyro.utils.validator_functions import force_literal_field
 
 
@@ -44,6 +46,22 @@ class HRIDataService(DCATDataService):
             "rdf_type": "uri"
         }
     )
+    applicable_legislation: List[AnyHttpUrl] = Field(
+        default=None,
+        description="The legislation that is applicable to this resource.",
+        json_schema_extra={
+            "rdf_term": DCATAPv3.applicableLegislation,
+            "rdf_type": "uri"
+        }
+    )
+    application_profile: List[AnyHttpUrl] = Field(
+        default=None,
+        description="An established standard to which the described resource conforms.",
+        json_schema_extra={
+            "rdf_term": DCTERMS.conformsTo,
+            "rdf_type": "uri"
+        }
+    )
     contact_point: Union[AnyHttpUrl, HRIVCard] = Field(
         description="Relevant contact information for the cataloged resource.",
         json_schema_extra={
@@ -51,10 +69,50 @@ class HRIDataService(DCATDataService):
             "rdf_type": "uri"
         }
     )
+    creator: List[Union[AnyHttpUrl, HRIAgent]] = Field(
+        default=None,
+        description="An entity responsible for making the resource.",
+        json_schema_extra={
+            "rdf_term": DCTERMS.creator,
+            "rdf_type": "uri"
+        }
+    )
+    rights: List[AnyHttpUrl] = Field(
+        default=None,
+        description="Information about rights held in and over the resource.",
+        json_schema_extra={
+            "rdf_term": DCTERMS.rights,
+            "rdf_type": "uri"
+        }
+    )
     endpoint_url: AnyHttpUrl = Field(
         description="The root location or primary endpoint of the service (a Web-resolvable IRI).",
         json_schema_extra={
             "rdf_term": DCAT.endpointURL,
+            "rdf_type": "uri"
+        }
+    )
+    format: List[AnyHttpUrl] = Field(
+        default=None,
+        description="The file format, physical medium, or dimensions of the resource.",
+        json_schema_extra={
+            "rdf_term": DCTERMS.format,
+            "rdf_type": "uri"
+        }
+    )
+    hvd_category: List[AnyHttpUrl] = Field( # IRI or skos:Concept
+        default=None,
+        description="A data category defined in the High Value Dataset Implementing Regulation.",
+        json_schema_extra={
+            "rdf_term": DCATAPv3.hvdCategory,
+            "rdf_type": "uri"
+        }
+    )
+    other_identifier: List[Union[AnyHttpUrl, Identifier]] = Field(
+        default=None,
+        description="Links a resource to an adms:Identifier class.",
+        json_schema_extra={
+            "rdf_term": ADMS.identifier,
             "rdf_type": "uri"
         }
     )

--- a/sempyro/namespaces/DCATAPv3.py
+++ b/sempyro/namespaces/DCATAPv3.py
@@ -30,6 +30,8 @@ class DCATAPv3(DefinedNamespace):
     """
 
     applicableLegislation: URIRef
+    availability: URIRef
+    hvdCategory: URIRef
 
     _NS = Namespace("http://data.europa.eu/r5r/")
 


### PR DESCRIPTION
## Summary by Sourcery

Add new v2 DCATAP recommended metadata fields to HRI data service, distribution, and catalog models, streamline agent and rights definitions, and introduce ADMS Identifier support

New Features:
- Add v2 recommended DCATAP fields (applicableLegislation, conformsTo, format, hvdCategory, otherIdentifier) to DataService, Distribution, and Catalog models

Enhancements:
- Remove legacy FOAF Agent and VCard definitions in favor of HRIAgent references in creator property
- Standardize rights property as URI array with updated description