### PR TITLE
feature: add DatasetSeries, Relationship, Attribution, and QualityCertificate support

### DIFF
--- a/models/dcat/Attribution.json
+++ b/models/dcat/Attribution.json
@@ -1,0 +1,145 @@
+{
+  "$IRI": "http://www.w3.org/ns/prov#Activity",
+  "$defs": {
+    "Agent": {
+      "$IRI": "http://xmlns.com/foaf/0.1/Agent",
+      "$namespace": "http://xmlns.com/foaf/0.1/",
+      "$ontology": "http://xmlns.com/foaf/spec/",
+      "$prefix": "foaf",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "A name of the agent",
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/LiteralField"
+              }
+            ]
+          },
+          "rdf_term": "http://xmlns.com/foaf/0.1/name",
+          "rdf_type": "rdfs_literal",
+          "title": "Name",
+          "type": "array"
+        },
+        "identifier": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/LiteralField"
+            }
+          ],
+          "description": "A unique identifier of the agent.",
+          "rdf_term": "http://purl.org/dc/terms/identifier",
+          "rdf_type": "rdfs_literal",
+          "title": "Identifier"
+        },
+        "mbox": {
+          "default": null,
+          "description": "A personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox.",
+          "items": {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          "rdf_term": "http://xmlns.com/foaf/0.1/mbox",
+          "rdf_type": "uri",
+          "title": "Mbox",
+          "type": "array"
+        },
+        "homepage": {
+          "default": null,
+          "description": "A webpage that either allows to make contact (i.e. a webform) or the information contains how to get into contact.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://xmlns.com/foaf/0.1/homepage",
+          "rdf_type": "uri",
+          "title": "Homepage",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "identifier"
+      ],
+      "title": "Agent",
+      "type": "object"
+    },
+    "LiteralField": {
+      "description": "Model to handle literal fields\nAttributes\n----------\ndatatype : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date' see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html, and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\nvalue : str\n    literal value\neither datatype or language, or none of these two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal",
+      "properties": {
+        "datatype": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": null,
+          "description": "datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes",
+          "title": "Datatype"
+        },
+        "language": {
+          "default": null,
+          "description": "RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,and also IANA-administrated namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry",
+          "title": "Language",
+          "type": "string"
+        },
+        "value": {
+          "description": "Field value",
+          "title": "Value",
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "title": "LiteralField",
+      "type": "object"
+    }
+  },
+  "$namespace": "http://www.w3.org/ns/prov#",
+  "$ontology": "https://www.w3.org/TR/prov-o/",
+  "$prefix": "prov",
+  "additionalProperties": false,
+  "properties": {
+    "agent": {
+      "anyOf": [
+        {
+          "format": "uri",
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Agent"
+        }
+      ],
+      "default": null,
+      "description": "The prov:agent property references an prov:Agent which influenced a resource.",
+      "rdf_term": "http://www.w3.org/ns/prov#agent",
+      "rdf_type": "uri",
+      "title": "Agent"
+    },
+    "role": {
+      "default": null,
+      "description": "The function of an entity or agent with respect to another entity or resource.",
+      "format": "uri",
+      "minLength": 1,
+      "rdf_term": "http://www.w3.org/ns/dcat#hadRole",
+      "rdf_type": "uri",
+      "title": "Role",
+      "type": "string"
+    }
+  },
+  "title": "Attribution",
+  "type": "object"
+}

--- a/models/dcat/Attribution.yaml
+++ b/models/dcat/Attribution.yaml
@@ -1,0 +1,115 @@
+$IRI: http://www.w3.org/ns/prov#Activity
+$defs:
+  Agent:
+    $IRI: http://xmlns.com/foaf/0.1/Agent
+    $namespace: http://xmlns.com/foaf/0.1/
+    $ontology: http://xmlns.com/foaf/spec/
+    $prefix: foaf
+    additionalProperties: false
+    properties:
+      name:
+        description: A name of the agent
+        items:
+          anyOf:
+          - type: string
+          - $ref: '#/$defs/LiteralField'
+        rdf_term: http://xmlns.com/foaf/0.1/name
+        rdf_type: rdfs_literal
+        title: Name
+        type: array
+      identifier:
+        anyOf:
+        - type: string
+        - $ref: '#/$defs/LiteralField'
+        description: A unique identifier of the agent.
+        rdf_term: http://purl.org/dc/terms/identifier
+        rdf_type: rdfs_literal
+        title: Identifier
+      mbox:
+        default:
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
+        items:
+          format: uri
+          minLength: 1
+          type: string
+        rdf_term: http://xmlns.com/foaf/0.1/mbox
+        rdf_type: uri
+        title: Mbox
+        type: array
+      homepage:
+        default:
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
+        format: uri
+        minLength: 1
+        rdf_term: http://xmlns.com/foaf/0.1/homepage
+        rdf_type: uri
+        title: Homepage
+        type: string
+    required:
+    - name
+    - identifier
+    title: Agent
+    type: object
+  LiteralField:
+    description: "Model to handle literal fields\nAttributes\n----------\ndatatype
+      : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
+      see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
+      \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
+      value : str\n    literal value\neither datatype or language, or none of these
+      two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
+    properties:
+      datatype:
+        anyOf:
+        - format: uri
+          minLength: 1
+          type: string
+        - type: string
+        default:
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        title: Datatype
+      language:
+        default:
+        description: 'RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,and
+          also IANA-administrated namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry'
+        title: Language
+        type: string
+      value:
+        description: Field value
+        title: Value
+        type: string
+    required:
+    - value
+    title: LiteralField
+    type: object
+$namespace: http://www.w3.org/ns/prov#
+$ontology: https://www.w3.org/TR/prov-o/
+$prefix: prov
+additionalProperties: false
+properties:
+  agent:
+    anyOf:
+    - format: uri
+      minLength: 1
+      type: string
+    - $ref: '#/$defs/Agent'
+    default:
+    description: The prov:agent property references an prov:Agent which influenced
+      a resource.
+    rdf_term: http://www.w3.org/ns/prov#agent
+    rdf_type: uri
+    title: Agent
+  role:
+    default:
+    description: The function of an entity or agent with respect to another entity
+      or resource.
+    format: uri
+    minLength: 1
+    rdf_term: http://www.w3.org/ns/dcat#hadRole
+    rdf_type: uri
+    title: Role
+    type: string
+title: Attribution
+type: object

--- a/models/dcat/Relationship.json
+++ b/models/dcat/Relationship.json
@@ -2,7 +2,7 @@
   "$IRI": "http://www.w3.org/ns/dcat#Relationship",
   "$namespace": "http://www.w3.org/ns/dcat#",
   "$ontology": "https://www.w3.org/TR/vocab-dcat-3/",
-  "$prefix": "prov",
+  "$prefix": "dcat",
   "additionalProperties": false,
   "properties": {
     "had_role": {

--- a/models/dcat/Relationship.json
+++ b/models/dcat/Relationship.json
@@ -1,0 +1,39 @@
+{
+  "$IRI": "http://www.w3.org/ns/dcat#Relationship",
+  "$namespace": "http://www.w3.org/ns/dcat#",
+  "$ontology": "https://www.w3.org/TR/vocab-dcat-3/",
+  "$prefix": "prov",
+  "additionalProperties": false,
+  "properties": {
+    "had_role": {
+      "description": "The function of an entity or agent with respect to another entity or resource.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
+      "rdf_term": "http://www.w3.org/ns/dcat#hadRole",
+      "rdf_type": "uri",
+      "title": "Had Role",
+      "type": "array"
+    },
+    "relation": {
+      "description": "A related resource.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
+      "rdf_term": "http://purl.org/dc/terms/relation",
+      "rdf_type": "uri",
+      "title": "Relation",
+      "type": "array"
+    }
+  },
+  "required": [
+    "had_role",
+    "relation"
+  ],
+  "title": "Relationship",
+  "type": "object"
+}

--- a/models/dcat/Relationship.yaml
+++ b/models/dcat/Relationship.yaml
@@ -1,7 +1,7 @@
 $IRI: http://www.w3.org/ns/dcat#Relationship
 $namespace: http://www.w3.org/ns/dcat#
 $ontology: https://www.w3.org/TR/vocab-dcat-3/
-$prefix: prov
+$prefix: dcat
 additionalProperties: false
 properties:
   had_role:

--- a/models/dcat/Relationship.yaml
+++ b/models/dcat/Relationship.yaml
@@ -1,0 +1,33 @@
+$IRI: http://www.w3.org/ns/dcat#Relationship
+$namespace: http://www.w3.org/ns/dcat#
+$ontology: https://www.w3.org/TR/vocab-dcat-3/
+$prefix: prov
+additionalProperties: false
+properties:
+  had_role:
+    description: The function of an entity or agent with respect to another entity
+      or resource.
+    items:
+      format: uri
+      minLength: 1
+      type: string
+    rdf_term: http://www.w3.org/ns/dcat#hadRole
+    rdf_type: uri
+    title: Had Role
+    type: array
+  relation:
+    description: A related resource.
+    items:
+      format: uri
+      minLength: 1
+      type: string
+    rdf_term: http://purl.org/dc/terms/relation
+    rdf_type: uri
+    title: Relation
+    type: array
+required:
+- had_role
+- relation
+title: Relationship
+type: object
+$defs: {}

--- a/models/hri_dcat/HRICatalog.json
+++ b/models/hri_dcat/HRICatalog.json
@@ -326,6 +326,44 @@
       "title": "Association",
       "type": "object"
     },
+    "Attribution": {
+      "$IRI": "http://www.w3.org/ns/prov#Activity",
+      "$namespace": "http://www.w3.org/ns/prov#",
+      "$ontology": "https://www.w3.org/TR/prov-o/",
+      "$prefix": "prov",
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/Agent"
+            }
+          ],
+          "default": null,
+          "description": "The prov:agent property references an prov:Agent which influenced a resource.",
+          "rdf_term": "http://www.w3.org/ns/prov#agent",
+          "rdf_type": "uri",
+          "title": "Agent"
+        },
+        "role": {
+          "default": null,
+          "description": "The function of an entity or agent with respect to another entity or resource.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/dcat#hadRole",
+          "rdf_type": "uri",
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "title": "Attribution",
+      "type": "object"
+    },
     "Checksum": {
       "$IRI": "http://spdx.org/rdf/terms#Checksum",
       "$namespace": "http://spdx.org/rdf/terms#",
@@ -4947,11 +4985,18 @@
         },
         "qualified_attribution": {
           "default": null,
-          "description": "Link to an Agent having some form of responsibility for the resource",
+          "description": "Attribution is the ascribing of an entity to an agent.",
           "items": {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uri",
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/Attribution"
+              }
+            ]
           },
           "rdf_term": "http://www.w3.org/ns/prov#qualifiedAttribution",
           "rdf_type": "uri",
@@ -5400,6 +5445,26 @@
           "rdf_term": "https://w3id.org/dpv#hasPurpose",
           "rdf_type": "uri",
           "title": "Purpose",
+          "type": "array"
+        },
+        "quality_annotation": {
+          "default": null,
+          "description": "Refers to a quality annotation.",
+          "items": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/QualityCertificate"
+              }
+            ]
+          },
+          "rdf_term": "http://www.w3.org/ns/dqv#hasQualityAnnotation",
+          "rdf_type": "uri",
+          "title": "Quality Annotation",
           "type": "array"
         },
         "retention_period": {
@@ -5914,6 +5979,37 @@
         }
       },
       "title": "PeriodOfTime",
+      "type": "object"
+    },
+    "QualityCertificate": {
+      "$IRI": "http://www.w3.org/ns/dqv#QualityCertificate",
+      "$namespace": "http://www.w3.org/ns/dqv#",
+      "$ontology": "https://www.w3.org/TR/vocab-dqv/",
+      "$prefix": "dqv",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "default": null,
+          "description": "The relationship between an Annotation and its Target.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/oa#hasTarget",
+          "rdf_type": "uri",
+          "title": "Target",
+          "type": "string"
+        },
+        "body": {
+          "default": null,
+          "description": "The object of the relationship is a resource that is a body of the Annotation.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/oa#hasBody",
+          "rdf_type": "uri",
+          "title": "Body",
+          "type": "string"
+        }
+      },
+      "title": "QualityCertificate",
       "type": "object"
     },
     "RDFModel": {

--- a/models/hri_dcat/HRICatalog.yaml
+++ b/models/hri_dcat/HRICatalog.yaml
@@ -330,6 +330,37 @@ $defs:
         type: string
     title: Association
     type: object
+  Attribution:
+    $IRI: http://www.w3.org/ns/prov#Activity
+    $namespace: http://www.w3.org/ns/prov#
+    $ontology: https://www.w3.org/TR/prov-o/
+    $prefix: prov
+    additionalProperties: false
+    properties:
+      agent:
+        anyOf:
+        - format: uri
+          minLength: 1
+          type: string
+        - $ref: '#/$defs/Agent'
+        default:
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource.
+        rdf_term: http://www.w3.org/ns/prov#agent
+        rdf_type: uri
+        title: Agent
+      role:
+        default:
+        description: The function of an entity or agent with respect to another entity
+          or resource.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/dcat#hadRole
+        rdf_type: uri
+        title: Role
+        type: string
+    title: Attribution
+    type: object
   Checksum:
     $IRI: http://spdx.org/rdf/terms#Checksum
     $namespace: http://spdx.org/rdf/terms#
@@ -4006,11 +4037,13 @@ $defs:
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the resource
+        description: Attribution is the ascribing of an entity to an agent.
         items:
-          format: uri
-          minLength: 1
-          type: string
+          anyOf:
+          - format: uri
+            minLength: 1
+            type: string
+          - $ref: '#/$defs/Attribution'
         rdf_term: http://www.w3.org/ns/prov#qualifiedAttribution
         rdf_type: uri
         title: Qualified Attribution
@@ -4351,6 +4384,19 @@ $defs:
         rdf_term: https://w3id.org/dpv#hasPurpose
         rdf_type: uri
         title: Purpose
+        type: array
+      quality_annotation:
+        default:
+        description: Refers to a quality annotation.
+        items:
+          anyOf:
+          - format: uri
+            minLength: 1
+            type: string
+          - $ref: '#/$defs/QualityCertificate'
+        rdf_term: http://www.w3.org/ns/dqv#hasQualityAnnotation
+        rdf_type: uri
+        title: Quality Annotation
         type: array
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
@@ -4760,6 +4806,34 @@ $defs:
         rdf_term: http://www.w3.org/2006/time#hasEnd
         rdf_type: http://www.w3.org/2006/time#Instant
     title: PeriodOfTime
+    type: object
+  QualityCertificate:
+    $IRI: http://www.w3.org/ns/dqv#QualityCertificate
+    $namespace: http://www.w3.org/ns/dqv#
+    $ontology: https://www.w3.org/TR/vocab-dqv/
+    $prefix: dqv
+    additionalProperties: false
+    properties:
+      target:
+        default:
+        description: The relationship between an Annotation and its Target.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/oa#hasTarget
+        rdf_type: uri
+        title: Target
+        type: string
+      body:
+        default:
+        description: The object of the relationship is a resource that is a body of
+          the Annotation.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/oa#hasBody
+        rdf_type: uri
+        title: Body
+        type: string
+    title: QualityCertificate
     type: object
   RDFModel:
     additionalProperties: false

--- a/models/hri_dcat/HRIDataService.json
+++ b/models/hri_dcat/HRIDataService.json
@@ -326,6 +326,44 @@
       "title": "Association",
       "type": "object"
     },
+    "Attribution": {
+      "$IRI": "http://www.w3.org/ns/prov#Activity",
+      "$namespace": "http://www.w3.org/ns/prov#",
+      "$ontology": "https://www.w3.org/TR/prov-o/",
+      "$prefix": "prov",
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/Agent"
+            }
+          ],
+          "default": null,
+          "description": "The prov:agent property references an prov:Agent which influenced a resource.",
+          "rdf_term": "http://www.w3.org/ns/prov#agent",
+          "rdf_type": "uri",
+          "title": "Agent"
+        },
+        "role": {
+          "default": null,
+          "description": "The function of an entity or agent with respect to another entity or resource.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/dcat#hadRole",
+          "rdf_type": "uri",
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "title": "Attribution",
+      "type": "object"
+    },
     "Checksum": {
       "$IRI": "http://spdx.org/rdf/terms#Checksum",
       "$namespace": "http://spdx.org/rdf/terms#",
@@ -3661,11 +3699,18 @@
         },
         "qualified_attribution": {
           "default": null,
-          "description": "Link to an Agent having some form of responsibility for the resource",
+          "description": "Attribution is the ascribing of an entity to an agent.",
           "items": {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uri",
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/Attribution"
+              }
+            ]
           },
           "rdf_term": "http://www.w3.org/ns/prov#qualifiedAttribution",
           "rdf_type": "uri",
@@ -4114,6 +4159,26 @@
           "rdf_term": "https://w3id.org/dpv#hasPurpose",
           "rdf_type": "uri",
           "title": "Purpose",
+          "type": "array"
+        },
+        "quality_annotation": {
+          "default": null,
+          "description": "Refers to a quality annotation.",
+          "items": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/QualityCertificate"
+              }
+            ]
+          },
+          "rdf_term": "http://www.w3.org/ns/dqv#hasQualityAnnotation",
+          "rdf_type": "uri",
+          "title": "Quality Annotation",
           "type": "array"
         },
         "retention_period": {
@@ -4628,6 +4693,37 @@
         }
       },
       "title": "PeriodOfTime",
+      "type": "object"
+    },
+    "QualityCertificate": {
+      "$IRI": "http://www.w3.org/ns/dqv#QualityCertificate",
+      "$namespace": "http://www.w3.org/ns/dqv#",
+      "$ontology": "https://www.w3.org/TR/vocab-dqv/",
+      "$prefix": "dqv",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "default": null,
+          "description": "The relationship between an Annotation and its Target.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/oa#hasTarget",
+          "rdf_type": "uri",
+          "title": "Target",
+          "type": "string"
+        },
+        "body": {
+          "default": null,
+          "description": "The object of the relationship is a resource that is a body of the Annotation.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/oa#hasBody",
+          "rdf_type": "uri",
+          "title": "Body",
+          "type": "string"
+        }
+      },
+      "title": "QualityCertificate",
       "type": "object"
     },
     "RDFModel": {

--- a/models/hri_dcat/HRIDataService.yaml
+++ b/models/hri_dcat/HRIDataService.yaml
@@ -330,6 +330,37 @@ $defs:
         type: string
     title: Association
     type: object
+  Attribution:
+    $IRI: http://www.w3.org/ns/prov#Activity
+    $namespace: http://www.w3.org/ns/prov#
+    $ontology: https://www.w3.org/TR/prov-o/
+    $prefix: prov
+    additionalProperties: false
+    properties:
+      agent:
+        anyOf:
+        - format: uri
+          minLength: 1
+          type: string
+        - $ref: '#/$defs/Agent'
+        default:
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource.
+        rdf_term: http://www.w3.org/ns/prov#agent
+        rdf_type: uri
+        title: Agent
+      role:
+        default:
+        description: The function of an entity or agent with respect to another entity
+          or resource.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/dcat#hadRole
+        rdf_type: uri
+        title: Role
+        type: string
+    title: Attribution
+    type: object
   Checksum:
     $IRI: http://spdx.org/rdf/terms#Checksum
     $namespace: http://spdx.org/rdf/terms#
@@ -2997,11 +3028,13 @@ $defs:
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the resource
+        description: Attribution is the ascribing of an entity to an agent.
         items:
-          format: uri
-          minLength: 1
-          type: string
+          anyOf:
+          - format: uri
+            minLength: 1
+            type: string
+          - $ref: '#/$defs/Attribution'
         rdf_term: http://www.w3.org/ns/prov#qualifiedAttribution
         rdf_type: uri
         title: Qualified Attribution
@@ -3342,6 +3375,19 @@ $defs:
         rdf_term: https://w3id.org/dpv#hasPurpose
         rdf_type: uri
         title: Purpose
+        type: array
+      quality_annotation:
+        default:
+        description: Refers to a quality annotation.
+        items:
+          anyOf:
+          - format: uri
+            minLength: 1
+            type: string
+          - $ref: '#/$defs/QualityCertificate'
+        rdf_term: http://www.w3.org/ns/dqv#hasQualityAnnotation
+        rdf_type: uri
+        title: Quality Annotation
         type: array
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
@@ -3751,6 +3797,34 @@ $defs:
         rdf_term: http://www.w3.org/2006/time#hasEnd
         rdf_type: http://www.w3.org/2006/time#Instant
     title: PeriodOfTime
+    type: object
+  QualityCertificate:
+    $IRI: http://www.w3.org/ns/dqv#QualityCertificate
+    $namespace: http://www.w3.org/ns/dqv#
+    $ontology: https://www.w3.org/TR/vocab-dqv/
+    $prefix: dqv
+    additionalProperties: false
+    properties:
+      target:
+        default:
+        description: The relationship between an Annotation and its Target.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/oa#hasTarget
+        rdf_type: uri
+        title: Target
+        type: string
+      body:
+        default:
+        description: The object of the relationship is a resource that is a body of
+          the Annotation.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/oa#hasBody
+        rdf_type: uri
+        title: Body
+        type: string
+    title: QualityCertificate
     type: object
   RDFModel:
     additionalProperties: false

--- a/models/hri_dcat/HRIDataset.json
+++ b/models/hri_dcat/HRIDataset.json
@@ -326,6 +326,44 @@
       "title": "Association",
       "type": "object"
     },
+    "Attribution": {
+      "$IRI": "http://www.w3.org/ns/prov#Activity",
+      "$namespace": "http://www.w3.org/ns/prov#",
+      "$ontology": "https://www.w3.org/TR/prov-o/",
+      "$prefix": "prov",
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/Agent"
+            }
+          ],
+          "default": null,
+          "description": "The prov:agent property references an prov:Agent which influenced a resource.",
+          "rdf_term": "http://www.w3.org/ns/prov#agent",
+          "rdf_type": "uri",
+          "title": "Agent"
+        },
+        "role": {
+          "default": null,
+          "description": "The function of an entity or agent with respect to another entity or resource.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/dcat#hadRole",
+          "rdf_type": "uri",
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "title": "Attribution",
+      "type": "object"
+    },
     "Checksum": {
       "$IRI": "http://spdx.org/rdf/terms#Checksum",
       "$namespace": "http://spdx.org/rdf/terms#",
@@ -3714,6 +3752,37 @@
       "title": "PeriodOfTime",
       "type": "object"
     },
+    "QualityCertificate": {
+      "$IRI": "http://www.w3.org/ns/dqv#QualityCertificate",
+      "$namespace": "http://www.w3.org/ns/dqv#",
+      "$ontology": "https://www.w3.org/TR/vocab-dqv/",
+      "$prefix": "dqv",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "default": null,
+          "description": "The relationship between an Annotation and its Target.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/oa#hasTarget",
+          "rdf_type": "uri",
+          "title": "Target",
+          "type": "string"
+        },
+        "body": {
+          "default": null,
+          "description": "The object of the relationship is a resource that is a body of the Annotation.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/oa#hasBody",
+          "rdf_type": "uri",
+          "title": "Body",
+          "type": "string"
+        }
+      },
+      "title": "QualityCertificate",
+      "type": "object"
+    },
     "RDFModel": {
       "additionalProperties": false,
       "description": "Base class for creating pydantic models convertible to RDF graph",
@@ -4288,11 +4357,18 @@
     },
     "qualified_attribution": {
       "default": null,
-      "description": "Link to an Agent having some form of responsibility for the resource",
+      "description": "Attribution is the ascribing of an entity to an agent.",
       "items": {
-        "format": "uri",
-        "minLength": 1,
-        "type": "string"
+        "anyOf": [
+          {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "$ref": "#/$defs/Attribution"
+          }
+        ]
       },
       "rdf_term": "http://www.w3.org/ns/prov#qualifiedAttribution",
       "rdf_type": "uri",
@@ -4741,6 +4817,26 @@
       "rdf_term": "https://w3id.org/dpv#hasPurpose",
       "rdf_type": "uri",
       "title": "Purpose",
+      "type": "array"
+    },
+    "quality_annotation": {
+      "default": null,
+      "description": "Refers to a quality annotation.",
+      "items": {
+        "anyOf": [
+          {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "$ref": "#/$defs/QualityCertificate"
+          }
+        ]
+      },
+      "rdf_term": "http://www.w3.org/ns/dqv#hasQualityAnnotation",
+      "rdf_type": "uri",
+      "title": "Quality Annotation",
       "type": "array"
     },
     "retention_period": {

--- a/models/hri_dcat/HRIDataset.yaml
+++ b/models/hri_dcat/HRIDataset.yaml
@@ -330,6 +330,37 @@ $defs:
         type: string
     title: Association
     type: object
+  Attribution:
+    $IRI: http://www.w3.org/ns/prov#Activity
+    $namespace: http://www.w3.org/ns/prov#
+    $ontology: https://www.w3.org/TR/prov-o/
+    $prefix: prov
+    additionalProperties: false
+    properties:
+      agent:
+        anyOf:
+        - format: uri
+          minLength: 1
+          type: string
+        - $ref: '#/$defs/Agent'
+        default:
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource.
+        rdf_term: http://www.w3.org/ns/prov#agent
+        rdf_type: uri
+        title: Agent
+      role:
+        default:
+        description: The function of an entity or agent with respect to another entity
+          or resource.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/dcat#hadRole
+        rdf_type: uri
+        title: Role
+        type: string
+    title: Attribution
+    type: object
   Checksum:
     $IRI: http://spdx.org/rdf/terms#Checksum
     $namespace: http://spdx.org/rdf/terms#
@@ -3056,6 +3087,34 @@ $defs:
         rdf_type: http://www.w3.org/2006/time#Instant
     title: PeriodOfTime
     type: object
+  QualityCertificate:
+    $IRI: http://www.w3.org/ns/dqv#QualityCertificate
+    $namespace: http://www.w3.org/ns/dqv#
+    $ontology: https://www.w3.org/TR/vocab-dqv/
+    $prefix: dqv
+    additionalProperties: false
+    properties:
+      target:
+        default:
+        description: The relationship between an Annotation and its Target.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/oa#hasTarget
+        rdf_type: uri
+        title: Target
+        type: string
+      body:
+        default:
+        description: The object of the relationship is a resource that is a body of
+          the Annotation.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/oa#hasBody
+        rdf_type: uri
+        title: Body
+        type: string
+    title: QualityCertificate
+    type: object
   RDFModel:
     additionalProperties: false
     description: Base class for creating pydantic models convertible to RDF graph
@@ -3541,11 +3600,13 @@ properties:
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the resource
+    description: Attribution is the ascribing of an entity to an agent.
     items:
-      format: uri
-      minLength: 1
-      type: string
+      anyOf:
+      - format: uri
+        minLength: 1
+        type: string
+      - $ref: '#/$defs/Attribution'
     rdf_term: http://www.w3.org/ns/prov#qualifiedAttribution
     rdf_type: uri
     title: Qualified Attribution
@@ -3884,6 +3945,19 @@ properties:
     rdf_term: https://w3id.org/dpv#hasPurpose
     rdf_type: uri
     title: Purpose
+    type: array
+  quality_annotation:
+    default:
+    description: Refers to a quality annotation.
+    items:
+      anyOf:
+      - format: uri
+        minLength: 1
+        type: string
+      - $ref: '#/$defs/QualityCertificate'
+    rdf_term: http://www.w3.org/ns/dqv#hasQualityAnnotation
+    rdf_type: uri
+    title: Quality Annotation
     type: array
   retention_period:
     $ref: '#/$defs/PeriodOfTime'

--- a/models/hri_dcat/HRIDatasetSeries.json
+++ b/models/hri_dcat/HRIDatasetSeries.json
@@ -211,6 +211,109 @@
       "title": "GeneralDateTimeDescription",
       "type": "object"
     },
+    "Geometry": {
+      "$IRI": "http://www.opengis.net/ont/geosparql#Geometry",
+      "$namespace": "http://www.opengis.net/ont/geosparql#",
+      "$ontology": "https://docs.ogc.org/is/22-047r1/22-047r1.html",
+      "$prefix": "geo",
+      "additionalProperties": false,
+      "description": "Geometry class for GeoSPARQL Geometry specification",
+      "properties": {
+        "dimension": {
+          "default": null,
+          "description": "The topological dimension of this geometric object, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this is the largest topological dimension of the contained objects.",
+          "rdf_term": "http://www.opengis.net/ont/geosparql#dimension",
+          "rdf_type": "xsd:integer",
+          "title": "Dimension",
+          "type": "integer"
+        },
+        "coordinateDimension": {
+          "default": null,
+          "description": "The number of measurements or axes needed to describe the position of this Geometry in a coordinate system.",
+          "rdf_term": "http://www.opengis.net/ont/geosparql#coordinateDimension",
+          "rdf_type": "xsd:integer",
+          "title": "Coordinatedimension",
+          "type": "integer"
+        },
+        "spatialDimension": {
+          "default": null,
+          "description": "The number of measurements or axes needed to describe the spatial position of this Geometry in a coordinate system.",
+          "rdf_term": "http://www.opengis.net/ont/geosparql#spatialDimension",
+          "rdf_type": "xsd:integer",
+          "title": "Spatialdimension",
+          "type": "integer"
+        },
+        "hasSpatialResolution": {
+          "default": null,
+          "description": "The spatial resolution of a Geometry",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.opengis.net/ont/geosparql#hasSpatialResolution",
+          "rdf_type": "uri",
+          "title": "Hasspatialresolution",
+          "type": "string"
+        },
+        "hasMetricSpatialResolution": {
+          "default": null,
+          "description": "The spatial resolution of a Geometry in meters.",
+          "rdf_term": "http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution",
+          "rdf_type": "xsd:double",
+          "title": "Hasmetricspatialresolution",
+          "type": "number"
+        },
+        "hasSpatialAccuracy": {
+          "default": null,
+          "description": "The positional accuracy of the coordinates of a Geometry",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.opengis.net/ont/geosparql#hasSpatialAccuracy",
+          "rdf_type": "uri",
+          "title": "Hasspatialaccuracy",
+          "type": "string"
+        },
+        "hasMetricSpatialAccuracy": {
+          "default": null,
+          "description": "The positional accuracy of the coordinates of a Geometry in meters.",
+          "rdf_term": "http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy",
+          "rdf_type": "xsd:double",
+          "title": "Hasmetricspatialaccuracy",
+          "type": "number"
+        },
+        "isEmpty": {
+          "default": null,
+          "description": "(true) if this geometric object is the empty Geometry. If true, then this geometric object represents the empty point set for the coordinate space.",
+          "rdf_term": "http://www.opengis.net/ont/geosparql#isEmpty",
+          "rdf_type": "xsd:boolean",
+          "title": "Isempty",
+          "type": "boolean"
+        },
+        "isSimple": {
+          "default": null,
+          "description": "(true) if this geometric object has no anomalous geometric points, such as self intersection or self tangency.",
+          "rdf_term": "http://www.opengis.net/ont/geosparql#isSimple",
+          "rdf_type": "xsd:boolean",
+          "title": "Issimple",
+          "type": "boolean"
+        },
+        "hasSerialization": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/LiteralField"
+            }
+          ],
+          "default": null,
+          "description": "Connects a Geometry object with its text-based serialization.",
+          "rdf_term": "http://www.opengis.net/ont/geosparql#hasSerialization",
+          "rdf_type": "rdfs_literal",
+          "title": "Hasserialization"
+        }
+      },
+      "title": "Geometry",
+      "type": "object"
+    },
     "LiteralField": {
       "description": "Model to handle literal fields\nAttributes\n----------\ndatatype : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date' see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html, and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\nvalue : str\n    literal value\neither datatype or language, or none of these two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal",
       "properties": {
@@ -245,6 +348,59 @@
         "value"
       ],
       "title": "LiteralField",
+      "type": "object"
+    },
+    "Location": {
+      "$IRI": "http://purl.org/dc/terms/Location",
+      "$namespace": "http://purl.org/dc/terms/",
+      "$ontology": "https://www.w3.org/TR/vocab-dcat-3/",
+      "$prefix": "dcterms",
+      "additionalProperties": false,
+      "description": "A spatial region or named place.",
+      "properties": {
+        "geometry": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LiteralField"
+            },
+            {
+              "$ref": "#/$defs/Geometry"
+            }
+          ],
+          "bind_namespace": [
+            "locn",
+            "http://www.w3.org/ns/locn#"
+          ],
+          "default": null,
+          "description": "Associates a spatial thing [SDW-BP] with a corresponding geometry.",
+          "rdf_term": "http://www.w3.org/ns/locn#geometry",
+          "rdf_type": "geosparql:wktLiteral",
+          "title": "Geometry"
+        },
+        "bounding_box": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LiteralField"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "default": null,
+          "description": "The geographic bounding box of a spatial thing [SDW-BP].",
+          "rdf_term": "http://www.w3.org/ns/dcat#bbox",
+          "rdf_type": "rdfs_literal",
+          "title": "Bounding Box"
+        },
+        "centroid": {
+          "$ref": "#/$defs/LiteralField",
+          "default": null,
+          "description": "The geographic center (centroid) of a spatial thing [SDW-BP].",
+          "rdf_term": "http://www.w3.org/ns/dcat#centroid",
+          "rdf_type": "geosparql:wktLiteral"
+        }
+      },
+      "title": "http://purl.org/dc/terms/Location",
       "type": "object"
     },
     "ODRLPolicy": {
@@ -755,7 +911,14 @@
     "description": {
       "description": "An account of the resource.",
       "items": {
-        "$ref": "#/$defs/LiteralField"
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/$defs/LiteralField"
+          }
+        ]
       },
       "rdf_term": "http://purl.org/dc/terms/description",
       "rdf_type": "rdfs_literal",
@@ -911,24 +1074,21 @@
       "type": "array"
     },
     "publisher": {
+      "anyOf": [
+        {
+          "format": "uri",
+          "minLength": 1,
+          "type": "string"
+        },
+        {
+          "$ref": "#/$defs/Agent"
+        }
+      ],
       "default": null,
       "description": "The entity responsible for making the resource available.",
-      "items": {
-        "anyOf": [
-          {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
-          },
-          {
-            "$ref": "#/$defs/Agent"
-          }
-        ]
-      },
       "rdf_term": "http://purl.org/dc/terms/publisher",
       "rdf_type": "uri",
-      "title": "Publisher",
-      "type": "array"
+      "title": "Publisher"
     },
     "release_date": {
       "anyOf": [
@@ -966,7 +1126,14 @@
     "title": {
       "description": "A name given to the resource.",
       "items": {
-        "$ref": "#/$defs/LiteralField"
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/$defs/LiteralField"
+          }
+        ]
       },
       "rdf_term": "http://purl.org/dc/terms/title",
       "rdf_type": "rdfs_literal",
@@ -1137,18 +1304,9 @@
     },
     "temporal_coverage": {
       "default": null,
-      "description": "Temporal characteristics of the resource.",
+      "description": "The temporal period that the dataset covers.",
       "items": {
-        "anyOf": [
-          {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
-          },
-          {
-            "$ref": "#/$defs/PeriodOfTime"
-          }
-        ]
+        "$ref": "#/$defs/PeriodOfTime"
       },
       "rdf_term": "http://purl.org/dc/terms/temporal",
       "rdf_type": "uri",
@@ -1157,11 +1315,18 @@
     },
     "geographical_coverage": {
       "default": null,
-      "description": "Spatial characteristics of the resource.",
+      "description": "The geographical area covered by the dataset.",
       "items": {
-        "format": "uri",
-        "minLength": 1,
-        "type": "string"
+        "anyOf": [
+          {
+            "format": "uri",
+            "minLength": 1,
+            "type": "string"
+          },
+          {
+            "$ref": "#/$defs/Location"
+          }
+        ]
       },
       "rdf_term": "http://purl.org/dc/terms/spatial",
       "rdf_type": "uri",

--- a/models/hri_dcat/HRIDatasetSeries.json
+++ b/models/hri_dcat/HRIDatasetSeries.json
@@ -211,109 +211,6 @@
       "title": "GeneralDateTimeDescription",
       "type": "object"
     },
-    "Geometry": {
-      "$IRI": "http://www.opengis.net/ont/geosparql#Geometry",
-      "$namespace": "http://www.opengis.net/ont/geosparql#",
-      "$ontology": "https://docs.ogc.org/is/22-047r1/22-047r1.html",
-      "$prefix": "geo",
-      "additionalProperties": false,
-      "description": "Geometry class for GeoSPARQL Geometry specification",
-      "properties": {
-        "dimension": {
-          "default": null,
-          "description": "The topological dimension of this geometric object, which must be less than or equal to the coordinate dimension. In non-homogeneous collections, this is the largest topological dimension of the contained objects.",
-          "rdf_term": "http://www.opengis.net/ont/geosparql#dimension",
-          "rdf_type": "xsd:integer",
-          "title": "Dimension",
-          "type": "integer"
-        },
-        "coordinateDimension": {
-          "default": null,
-          "description": "The number of measurements or axes needed to describe the position of this Geometry in a coordinate system.",
-          "rdf_term": "http://www.opengis.net/ont/geosparql#coordinateDimension",
-          "rdf_type": "xsd:integer",
-          "title": "Coordinatedimension",
-          "type": "integer"
-        },
-        "spatialDimension": {
-          "default": null,
-          "description": "The number of measurements or axes needed to describe the spatial position of this Geometry in a coordinate system.",
-          "rdf_term": "http://www.opengis.net/ont/geosparql#spatialDimension",
-          "rdf_type": "xsd:integer",
-          "title": "Spatialdimension",
-          "type": "integer"
-        },
-        "hasSpatialResolution": {
-          "default": null,
-          "description": "The spatial resolution of a Geometry",
-          "format": "uri",
-          "minLength": 1,
-          "rdf_term": "http://www.opengis.net/ont/geosparql#hasSpatialResolution",
-          "rdf_type": "uri",
-          "title": "Hasspatialresolution",
-          "type": "string"
-        },
-        "hasMetricSpatialResolution": {
-          "default": null,
-          "description": "The spatial resolution of a Geometry in meters.",
-          "rdf_term": "http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution",
-          "rdf_type": "xsd:double",
-          "title": "Hasmetricspatialresolution",
-          "type": "number"
-        },
-        "hasSpatialAccuracy": {
-          "default": null,
-          "description": "The positional accuracy of the coordinates of a Geometry",
-          "format": "uri",
-          "minLength": 1,
-          "rdf_term": "http://www.opengis.net/ont/geosparql#hasSpatialAccuracy",
-          "rdf_type": "uri",
-          "title": "Hasspatialaccuracy",
-          "type": "string"
-        },
-        "hasMetricSpatialAccuracy": {
-          "default": null,
-          "description": "The positional accuracy of the coordinates of a Geometry in meters.",
-          "rdf_term": "http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy",
-          "rdf_type": "xsd:double",
-          "title": "Hasmetricspatialaccuracy",
-          "type": "number"
-        },
-        "isEmpty": {
-          "default": null,
-          "description": "(true) if this geometric object is the empty Geometry. If true, then this geometric object represents the empty point set for the coordinate space.",
-          "rdf_term": "http://www.opengis.net/ont/geosparql#isEmpty",
-          "rdf_type": "xsd:boolean",
-          "title": "Isempty",
-          "type": "boolean"
-        },
-        "isSimple": {
-          "default": null,
-          "description": "(true) if this geometric object has no anomalous geometric points, such as self intersection or self tangency.",
-          "rdf_term": "http://www.opengis.net/ont/geosparql#isSimple",
-          "rdf_type": "xsd:boolean",
-          "title": "Issimple",
-          "type": "boolean"
-        },
-        "hasSerialization": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/$defs/LiteralField"
-            }
-          ],
-          "default": null,
-          "description": "Connects a Geometry object with its text-based serialization.",
-          "rdf_term": "http://www.opengis.net/ont/geosparql#hasSerialization",
-          "rdf_type": "rdfs_literal",
-          "title": "Hasserialization"
-        }
-      },
-      "title": "Geometry",
-      "type": "object"
-    },
     "LiteralField": {
       "description": "Model to handle literal fields\nAttributes\n----------\ndatatype : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date' see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html, and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\nvalue : str\n    literal value\neither datatype or language, or none of these two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal",
       "properties": {
@@ -348,59 +245,6 @@
         "value"
       ],
       "title": "LiteralField",
-      "type": "object"
-    },
-    "Location": {
-      "$IRI": "http://purl.org/dc/terms/Location",
-      "$namespace": "http://purl.org/dc/terms/",
-      "$ontology": "https://www.w3.org/TR/vocab-dcat-3/",
-      "$prefix": "dcterms",
-      "additionalProperties": false,
-      "description": "A spatial region or named place.",
-      "properties": {
-        "geometry": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LiteralField"
-            },
-            {
-              "$ref": "#/$defs/Geometry"
-            }
-          ],
-          "bind_namespace": [
-            "locn",
-            "http://www.w3.org/ns/locn#"
-          ],
-          "default": null,
-          "description": "Associates a spatial thing [SDW-BP] with a corresponding geometry.",
-          "rdf_term": "http://www.w3.org/ns/locn#geometry",
-          "rdf_type": "geosparql:wktLiteral",
-          "title": "Geometry"
-        },
-        "bounding_box": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LiteralField"
-            },
-            {
-              "type": "string"
-            }
-          ],
-          "default": null,
-          "description": "The geographic bounding box of a spatial thing [SDW-BP].",
-          "rdf_term": "http://www.w3.org/ns/dcat#bbox",
-          "rdf_type": "rdfs_literal",
-          "title": "Bounding Box"
-        },
-        "centroid": {
-          "$ref": "#/$defs/LiteralField",
-          "default": null,
-          "description": "The geographic center (centroid) of a spatial thing [SDW-BP].",
-          "rdf_term": "http://www.w3.org/ns/dcat#centroid",
-          "rdf_type": "geosparql:wktLiteral"
-        }
-      },
-      "title": "http://purl.org/dc/terms/Location",
       "type": "object"
     },
     "ODRLPolicy": {
@@ -867,7 +711,7 @@
     },
     "contact_point": {
       "default": null,
-      "description": "Relevant contact information for the cataloged resource. Use of vCard is recommended",
+      "description": "Relevant contact information for the cataloged resource.",
       "items": {
         "anyOf": [
           {
@@ -877,9 +721,6 @@
           },
           {
             "$ref": "#/$defs/VCard"
-          },
-          {
-            "$ref": "#/$defs/Agent"
           }
         ]
       },
@@ -1296,18 +1137,7 @@
     },
     "temporal_coverage": {
       "default": null,
-      "description": "The temporal period that the dataset covers.",
-      "items": {
-        "$ref": "#/$defs/PeriodOfTime"
-      },
-      "rdf_term": "http://purl.org/dc/terms/temporal",
-      "rdf_type": "uri",
-      "title": "Temporal Coverage",
-      "type": "array"
-    },
-    "geographical_coverage": {
-      "default": null,
-      "description": "The geographical area covered by the dataset.",
+      "description": "Temporal characteristics of the resource.",
       "items": {
         "anyOf": [
           {
@@ -1316,14 +1146,50 @@
             "type": "string"
           },
           {
-            "$ref": "#/$defs/Location"
+            "$ref": "#/$defs/PeriodOfTime"
           }
         ]
+      },
+      "rdf_term": "http://purl.org/dc/terms/temporal",
+      "rdf_type": "uri",
+      "title": "Temporal Coverage",
+      "type": "array"
+    },
+    "geographical_coverage": {
+      "default": null,
+      "description": "Spatial characteristics of the resource.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
       },
       "rdf_term": "http://purl.org/dc/terms/spatial",
       "rdf_type": "uri",
       "title": "Geographical Coverage",
       "type": "array"
+    },
+    "applicable_legislation": {
+      "default": null,
+      "description": "The legislation that is applicable to this resource.",
+      "items": {
+        "format": "uri",
+        "minLength": 1,
+        "type": "string"
+      },
+      "rdf_term": "http://data.europa.eu/r5r/applicableLegislation",
+      "rdf_type": "uri",
+      "title": "Applicable Legislation",
+      "type": "array"
+    },
+    "frequency": {
+      "default": null,
+      "description": "The frequency with which items are added to a collection.",
+      "format": "uri",
+      "minLength": 1,
+      "rdf_term": "http://purl.org/dc/terms/accrualPeriodicity",
+      "rdf_type": "uri",
+      "title": "Frequency",
+      "type": "string"
     }
   },
   "required": [

--- a/models/hri_dcat/HRIDatasetSeries.yaml
+++ b/models/hri_dcat/HRIDatasetSeries.yaml
@@ -184,6 +184,99 @@ $defs:
     - hasTRS
     title: GeneralDateTimeDescription
     type: object
+  Geometry:
+    $IRI: http://www.opengis.net/ont/geosparql#Geometry
+    $namespace: http://www.opengis.net/ont/geosparql#
+    $ontology: https://docs.ogc.org/is/22-047r1/22-047r1.html
+    $prefix: geo
+    additionalProperties: false
+    description: Geometry class for GeoSPARQL Geometry specification
+    properties:
+      dimension:
+        default:
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
+        rdf_term: http://www.opengis.net/ont/geosparql#dimension
+        rdf_type: xsd:integer
+        title: Dimension
+        type: integer
+      coordinateDimension:
+        default:
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
+        rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
+        rdf_type: xsd:integer
+        title: Coordinatedimension
+        type: integer
+      spatialDimension:
+        default:
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
+        rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
+        rdf_type: xsd:integer
+        title: Spatialdimension
+        type: integer
+      hasSpatialResolution:
+        default:
+        description: The spatial resolution of a Geometry
+        format: uri
+        minLength: 1
+        rdf_term: http://www.opengis.net/ont/geosparql#hasSpatialResolution
+        rdf_type: uri
+        title: Hasspatialresolution
+        type: string
+      hasMetricSpatialResolution:
+        default:
+        description: The spatial resolution of a Geometry in meters.
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_type: xsd:double
+        title: Hasmetricspatialresolution
+        type: number
+      hasSpatialAccuracy:
+        default:
+        description: The positional accuracy of the coordinates of a Geometry
+        format: uri
+        minLength: 1
+        rdf_term: http://www.opengis.net/ont/geosparql#hasSpatialAccuracy
+        rdf_type: uri
+        title: Hasspatialaccuracy
+        type: string
+      hasMetricSpatialAccuracy:
+        default:
+        description: The positional accuracy of the coordinates of a Geometry in meters.
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
+        rdf_type: xsd:double
+        title: Hasmetricspatialaccuracy
+        type: number
+      isEmpty:
+        default:
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
+        rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
+        rdf_type: xsd:boolean
+        title: Isempty
+        type: boolean
+      isSimple:
+        default:
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
+        rdf_term: http://www.opengis.net/ont/geosparql#isSimple
+        rdf_type: xsd:boolean
+        title: Issimple
+        type: boolean
+      hasSerialization:
+        anyOf:
+        - type: string
+        - $ref: '#/$defs/LiteralField'
+        default:
+        description: Connects a Geometry object with its text-based serialization.
+        rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
+        rdf_type: rdfs_literal
+        title: Hasserialization
+    title: Geometry
+    type: object
   LiteralField:
     description: "Model to handle literal fields\nAttributes\n----------\ndatatype
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
@@ -215,6 +308,43 @@ $defs:
     required:
     - value
     title: LiteralField
+    type: object
+  Location:
+    $IRI: http://purl.org/dc/terms/Location
+    $namespace: http://purl.org/dc/terms/
+    $ontology: https://www.w3.org/TR/vocab-dcat-3/
+    $prefix: dcterms
+    additionalProperties: false
+    description: A spatial region or named place.
+    properties:
+      geometry:
+        anyOf:
+        - $ref: '#/$defs/LiteralField'
+        - $ref: '#/$defs/Geometry'
+        bind_namespace:
+        - locn
+        - http://www.w3.org/ns/locn#
+        default:
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
+        rdf_term: http://www.w3.org/ns/locn#geometry
+        rdf_type: geosparql:wktLiteral
+        title: Geometry
+      bounding_box:
+        anyOf:
+        - $ref: '#/$defs/LiteralField'
+        - type: string
+        default:
+        description: The geographic bounding box of a spatial thing [SDW-BP].
+        rdf_term: http://www.w3.org/ns/dcat#bbox
+        rdf_type: rdfs_literal
+        title: Bounding Box
+      centroid:
+        $ref: '#/$defs/LiteralField'
+        default:
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
+        rdf_term: http://www.w3.org/ns/dcat#centroid
+        rdf_type: geosparql:wktLiteral
+    title: http://purl.org/dc/terms/Location
     type: object
   ODRLPolicy:
     $IRI: http://www.w3.org/ns/odrl/2/Policy
@@ -643,7 +773,9 @@ properties:
   description:
     description: An account of the resource.
     items:
-      $ref: '#/$defs/LiteralField'
+      anyOf:
+      - type: string
+      - $ref: '#/$defs/LiteralField'
     rdf_term: http://purl.org/dc/terms/description
     rdf_type: rdfs_literal
     title: Description
@@ -771,18 +903,16 @@ properties:
     title: Qualified Relation
     type: array
   publisher:
+    anyOf:
+    - format: uri
+      minLength: 1
+      type: string
+    - $ref: '#/$defs/Agent'
     default:
     description: The entity responsible for making the resource available.
-    items:
-      anyOf:
-      - format: uri
-        minLength: 1
-        type: string
-      - $ref: '#/$defs/Agent'
     rdf_term: http://purl.org/dc/terms/publisher
     rdf_type: uri
     title: Publisher
-    type: array
   release_date:
     anyOf:
     - type: string
@@ -809,7 +939,9 @@ properties:
   title:
     description: A name given to the resource.
     items:
-      $ref: '#/$defs/LiteralField'
+      anyOf:
+      - type: string
+      - $ref: '#/$defs/LiteralField'
     rdf_term: http://purl.org/dc/terms/title
     rdf_type: rdfs_literal
     title: Title
@@ -950,24 +1082,22 @@ properties:
     type: array
   temporal_coverage:
     default:
-    description: Temporal characteristics of the resource.
+    description: The temporal period that the dataset covers.
     items:
-      anyOf:
-      - format: uri
-        minLength: 1
-        type: string
-      - $ref: '#/$defs/PeriodOfTime'
+      $ref: '#/$defs/PeriodOfTime'
     rdf_term: http://purl.org/dc/terms/temporal
     rdf_type: uri
     title: Temporal Coverage
     type: array
   geographical_coverage:
     default:
-    description: Spatial characteristics of the resource.
+    description: The geographical area covered by the dataset.
     items:
-      format: uri
-      minLength: 1
-      type: string
+      anyOf:
+      - format: uri
+        minLength: 1
+        type: string
+      - $ref: '#/$defs/Location'
     rdf_term: http://purl.org/dc/terms/spatial
     rdf_type: uri
     title: Geographical Coverage

--- a/models/hri_dcat/HRIDatasetSeries.yaml
+++ b/models/hri_dcat/HRIDatasetSeries.yaml
@@ -184,99 +184,6 @@ $defs:
     - hasTRS
     title: GeneralDateTimeDescription
     type: object
-  Geometry:
-    $IRI: http://www.opengis.net/ont/geosparql#Geometry
-    $namespace: http://www.opengis.net/ont/geosparql#
-    $ontology: https://docs.ogc.org/is/22-047r1/22-047r1.html
-    $prefix: geo
-    additionalProperties: false
-    description: Geometry class for GeoSPARQL Geometry specification
-    properties:
-      dimension:
-        default:
-        description: The topological dimension of this geometric object, which must
-          be less than or equal to the coordinate dimension. In non-homogeneous collections,
-          this is the largest topological dimension of the contained objects.
-        rdf_term: http://www.opengis.net/ont/geosparql#dimension
-        rdf_type: xsd:integer
-        title: Dimension
-        type: integer
-      coordinateDimension:
-        default:
-        description: The number of measurements or axes needed to describe the position
-          of this Geometry in a coordinate system.
-        rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
-        rdf_type: xsd:integer
-        title: Coordinatedimension
-        type: integer
-      spatialDimension:
-        default:
-        description: The number of measurements or axes needed to describe the spatial
-          position of this Geometry in a coordinate system.
-        rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
-        rdf_type: xsd:integer
-        title: Spatialdimension
-        type: integer
-      hasSpatialResolution:
-        default:
-        description: The spatial resolution of a Geometry
-        format: uri
-        minLength: 1
-        rdf_term: http://www.opengis.net/ont/geosparql#hasSpatialResolution
-        rdf_type: uri
-        title: Hasspatialresolution
-        type: string
-      hasMetricSpatialResolution:
-        default:
-        description: The spatial resolution of a Geometry in meters.
-        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
-        rdf_type: xsd:double
-        title: Hasmetricspatialresolution
-        type: number
-      hasSpatialAccuracy:
-        default:
-        description: The positional accuracy of the coordinates of a Geometry
-        format: uri
-        minLength: 1
-        rdf_term: http://www.opengis.net/ont/geosparql#hasSpatialAccuracy
-        rdf_type: uri
-        title: Hasspatialaccuracy
-        type: string
-      hasMetricSpatialAccuracy:
-        default:
-        description: The positional accuracy of the coordinates of a Geometry in meters.
-        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
-        rdf_type: xsd:double
-        title: Hasmetricspatialaccuracy
-        type: number
-      isEmpty:
-        default:
-        description: (true) if this geometric object is the empty Geometry. If true,
-          then this geometric object represents the empty point set for the coordinate
-          space.
-        rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
-        rdf_type: xsd:boolean
-        title: Isempty
-        type: boolean
-      isSimple:
-        default:
-        description: (true) if this geometric object has no anomalous geometric points,
-          such as self intersection or self tangency.
-        rdf_term: http://www.opengis.net/ont/geosparql#isSimple
-        rdf_type: xsd:boolean
-        title: Issimple
-        type: boolean
-      hasSerialization:
-        anyOf:
-        - type: string
-        - $ref: '#/$defs/LiteralField'
-        default:
-        description: Connects a Geometry object with its text-based serialization.
-        rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
-        rdf_type: rdfs_literal
-        title: Hasserialization
-    title: Geometry
-    type: object
   LiteralField:
     description: "Model to handle literal fields\nAttributes\n----------\ndatatype
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
@@ -308,43 +215,6 @@ $defs:
     required:
     - value
     title: LiteralField
-    type: object
-  Location:
-    $IRI: http://purl.org/dc/terms/Location
-    $namespace: http://purl.org/dc/terms/
-    $ontology: https://www.w3.org/TR/vocab-dcat-3/
-    $prefix: dcterms
-    additionalProperties: false
-    description: A spatial region or named place.
-    properties:
-      geometry:
-        anyOf:
-        - $ref: '#/$defs/LiteralField'
-        - $ref: '#/$defs/Geometry'
-        bind_namespace:
-        - locn
-        - http://www.w3.org/ns/locn#
-        default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
-        rdf_term: http://www.w3.org/ns/locn#geometry
-        rdf_type: geosparql:wktLiteral
-        title: Geometry
-      bounding_box:
-        anyOf:
-        - $ref: '#/$defs/LiteralField'
-        - type: string
-        default:
-        description: The geographic bounding box of a spatial thing [SDW-BP].
-        rdf_term: http://www.w3.org/ns/dcat#bbox
-        rdf_type: rdfs_literal
-        title: Bounding Box
-      centroid:
-        $ref: '#/$defs/LiteralField'
-        default:
-        description: The geographic center (centroid) of a spatial thing [SDW-BP].
-        rdf_term: http://www.w3.org/ns/dcat#centroid
-        rdf_type: geosparql:wktLiteral
-    title: http://purl.org/dc/terms/Location
     type: object
   ODRLPolicy:
     $IRI: http://www.w3.org/ns/odrl/2/Policy
@@ -744,15 +614,13 @@ properties:
     type: string
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of vCard
-      is recommended
+    description: Relevant contact information for the cataloged resource.
     items:
       anyOf:
       - format: uri
         minLength: 1
         type: string
       - $ref: '#/$defs/VCard'
-      - $ref: '#/$defs/Agent'
     rdf_term: http://www.w3.org/ns/dcat#contactPoint
     rdf_type: uri
     title: Contact Point
@@ -1082,26 +950,48 @@ properties:
     type: array
   temporal_coverage:
     default:
-    description: The temporal period that the dataset covers.
+    description: Temporal characteristics of the resource.
     items:
-      $ref: '#/$defs/PeriodOfTime'
+      anyOf:
+      - format: uri
+        minLength: 1
+        type: string
+      - $ref: '#/$defs/PeriodOfTime'
     rdf_term: http://purl.org/dc/terms/temporal
     rdf_type: uri
     title: Temporal Coverage
     type: array
   geographical_coverage:
     default:
-    description: The geographical area covered by the dataset.
+    description: Spatial characteristics of the resource.
     items:
-      anyOf:
-      - format: uri
-        minLength: 1
-        type: string
-      - $ref: '#/$defs/Location'
+      format: uri
+      minLength: 1
+      type: string
     rdf_term: http://purl.org/dc/terms/spatial
     rdf_type: uri
     title: Geographical Coverage
     type: array
+  applicable_legislation:
+    default:
+    description: The legislation that is applicable to this resource.
+    items:
+      format: uri
+      minLength: 1
+      type: string
+    rdf_term: http://data.europa.eu/r5r/applicableLegislation
+    rdf_type: uri
+    title: Applicable Legislation
+    type: array
+  frequency:
+    default:
+    description: The frequency with which items are added to a collection.
+    format: uri
+    minLength: 1
+    rdf_term: http://purl.org/dc/terms/accrualPeriodicity
+    rdf_type: uri
+    title: Frequency
+    type: string
 required:
 - description
 - title

--- a/models/hri_dcat/HRIDistribution.json
+++ b/models/hri_dcat/HRIDistribution.json
@@ -326,6 +326,44 @@
       "title": "Association",
       "type": "object"
     },
+    "Attribution": {
+      "$IRI": "http://www.w3.org/ns/prov#Activity",
+      "$namespace": "http://www.w3.org/ns/prov#",
+      "$ontology": "https://www.w3.org/TR/prov-o/",
+      "$prefix": "prov",
+      "additionalProperties": false,
+      "properties": {
+        "agent": {
+          "anyOf": [
+            {
+              "format": "uri",
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "$ref": "#/$defs/Agent"
+            }
+          ],
+          "default": null,
+          "description": "The prov:agent property references an prov:Agent which influenced a resource.",
+          "rdf_term": "http://www.w3.org/ns/prov#agent",
+          "rdf_type": "uri",
+          "title": "Agent"
+        },
+        "role": {
+          "default": null,
+          "description": "The function of an entity or agent with respect to another entity or resource.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/dcat#hadRole",
+          "rdf_type": "uri",
+          "title": "Role",
+          "type": "string"
+        }
+      },
+      "title": "Attribution",
+      "type": "object"
+    },
     "Checksum": {
       "$IRI": "http://spdx.org/rdf/terms#Checksum",
       "$namespace": "http://spdx.org/rdf/terms#",
@@ -4267,11 +4305,18 @@
         },
         "qualified_attribution": {
           "default": null,
-          "description": "Link to an Agent having some form of responsibility for the resource",
+          "description": "Attribution is the ascribing of an entity to an agent.",
           "items": {
-            "format": "uri",
-            "minLength": 1,
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uri",
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/Attribution"
+              }
+            ]
           },
           "rdf_term": "http://www.w3.org/ns/prov#qualifiedAttribution",
           "rdf_type": "uri",
@@ -4720,6 +4765,26 @@
           "rdf_term": "https://w3id.org/dpv#hasPurpose",
           "rdf_type": "uri",
           "title": "Purpose",
+          "type": "array"
+        },
+        "quality_annotation": {
+          "default": null,
+          "description": "Refers to a quality annotation.",
+          "items": {
+            "anyOf": [
+              {
+                "format": "uri",
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "$ref": "#/$defs/QualityCertificate"
+              }
+            ]
+          },
+          "rdf_term": "http://www.w3.org/ns/dqv#hasQualityAnnotation",
+          "rdf_type": "uri",
+          "title": "Quality Annotation",
           "type": "array"
         },
         "retention_period": {
@@ -5234,6 +5299,37 @@
         }
       },
       "title": "PeriodOfTime",
+      "type": "object"
+    },
+    "QualityCertificate": {
+      "$IRI": "http://www.w3.org/ns/dqv#QualityCertificate",
+      "$namespace": "http://www.w3.org/ns/dqv#",
+      "$ontology": "https://www.w3.org/TR/vocab-dqv/",
+      "$prefix": "dqv",
+      "additionalProperties": false,
+      "properties": {
+        "target": {
+          "default": null,
+          "description": "The relationship between an Annotation and its Target.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/oa#hasTarget",
+          "rdf_type": "uri",
+          "title": "Target",
+          "type": "string"
+        },
+        "body": {
+          "default": null,
+          "description": "The object of the relationship is a resource that is a body of the Annotation.",
+          "format": "uri",
+          "minLength": 1,
+          "rdf_term": "http://www.w3.org/ns/oa#hasBody",
+          "rdf_type": "uri",
+          "title": "Body",
+          "type": "string"
+        }
+      },
+      "title": "QualityCertificate",
       "type": "object"
     },
     "RDFModel": {

--- a/models/hri_dcat/HRIDistribution.yaml
+++ b/models/hri_dcat/HRIDistribution.yaml
@@ -330,6 +330,37 @@ $defs:
         type: string
     title: Association
     type: object
+  Attribution:
+    $IRI: http://www.w3.org/ns/prov#Activity
+    $namespace: http://www.w3.org/ns/prov#
+    $ontology: https://www.w3.org/TR/prov-o/
+    $prefix: prov
+    additionalProperties: false
+    properties:
+      agent:
+        anyOf:
+        - format: uri
+          minLength: 1
+          type: string
+        - $ref: '#/$defs/Agent'
+        default:
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource.
+        rdf_term: http://www.w3.org/ns/prov#agent
+        rdf_type: uri
+        title: Agent
+      role:
+        default:
+        description: The function of an entity or agent with respect to another entity
+          or resource.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/dcat#hadRole
+        rdf_type: uri
+        title: Role
+        type: string
+    title: Attribution
+    type: object
   Checksum:
     $IRI: http://spdx.org/rdf/terms#Checksum
     $namespace: http://spdx.org/rdf/terms#
@@ -3478,11 +3509,13 @@ $defs:
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the resource
+        description: Attribution is the ascribing of an entity to an agent.
         items:
-          format: uri
-          minLength: 1
-          type: string
+          anyOf:
+          - format: uri
+            minLength: 1
+            type: string
+          - $ref: '#/$defs/Attribution'
         rdf_term: http://www.w3.org/ns/prov#qualifiedAttribution
         rdf_type: uri
         title: Qualified Attribution
@@ -3823,6 +3856,19 @@ $defs:
         rdf_term: https://w3id.org/dpv#hasPurpose
         rdf_type: uri
         title: Purpose
+        type: array
+      quality_annotation:
+        default:
+        description: Refers to a quality annotation.
+        items:
+          anyOf:
+          - format: uri
+            minLength: 1
+            type: string
+          - $ref: '#/$defs/QualityCertificate'
+        rdf_term: http://www.w3.org/ns/dqv#hasQualityAnnotation
+        rdf_type: uri
+        title: Quality Annotation
         type: array
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
@@ -4232,6 +4278,34 @@ $defs:
         rdf_term: http://www.w3.org/2006/time#hasEnd
         rdf_type: http://www.w3.org/2006/time#Instant
     title: PeriodOfTime
+    type: object
+  QualityCertificate:
+    $IRI: http://www.w3.org/ns/dqv#QualityCertificate
+    $namespace: http://www.w3.org/ns/dqv#
+    $ontology: https://www.w3.org/TR/vocab-dqv/
+    $prefix: dqv
+    additionalProperties: false
+    properties:
+      target:
+        default:
+        description: The relationship between an Annotation and its Target.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/oa#hasTarget
+        rdf_type: uri
+        title: Target
+        type: string
+      body:
+        default:
+        description: The object of the relationship is a resource that is a body of
+          the Annotation.
+        format: uri
+        minLength: 1
+        rdf_term: http://www.w3.org/ns/oa#hasBody
+        rdf_type: uri
+        title: Body
+        type: string
+    title: QualityCertificate
     type: object
   RDFModel:
     additionalProperties: false

--- a/sempyro/dcat/__init__.py
+++ b/sempyro/dcat/__init__.py
@@ -4,6 +4,8 @@ from .dcat_catalog import DCATCatalog
 from .dataset_series import DCATDatasetSeries
 from .data_service import DCATDataService
 from .dcat_distribution import DCATDistribution
+from .dcat_relationship import Relationship
+from .dcat_attribution import Attribution
 
 __all__ = (
     # dcat rdf model classes
@@ -13,6 +15,8 @@ __all__ = (
     "DCATDistribution",
     "DCATDatasetSeries",
     "DCATDataService",
+    "Relationship",
+    "Attribution",
     # enum classes
     "Status",
     "AccessRights",

--- a/sempyro/dcat/dcat_attribution.py
+++ b/sempyro/dcat/dcat_attribution.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Stichting Health-RI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from typing import Union
+
+from pydantic import ConfigDict, AnyHttpUrl, Field
+from rdflib.namespace import DCAT, PROV
+
+from sempyro import RDFModel
+from sempyro.foaf import Agent
+
+class Attribution(RDFModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "$ontology": "https://www.w3.org/TR/prov-o/",
+            "$namespace": str(PROV),
+            "$IRI": PROV.Activity,
+            "$prefix": "prov"
+        }
+    )
+
+    agent: Union[AnyHttpUrl, Agent] = Field(
+        default=None,
+        description="The prov:agent property references an prov:Agent which influenced a resource.",
+        json_schema_extra={
+            "rdf_term": PROV.agent,
+            "rdf_type": "uri"
+        }
+    )
+    role: AnyHttpUrl = Field(
+        default=None,
+        description="The function of an entity or agent with respect to another entity or resource.",
+        json_schema_extra={
+            "rdf_term": DCAT.hadRole,
+            "rdf_type": "uri"
+        }
+    )
+
+if __name__ == "__main__":
+    json_models_folder = Path(Path(__file__).parents[2].resolve(), "models", "dcat")
+    Attribution.save_schema_to_file(path=Path(json_models_folder, "Attribution.json"), file_format="json")
+    Attribution.save_schema_to_file(path=Path(json_models_folder, "Attribution.yaml"), file_format="yaml")

--- a/sempyro/dcat/dcat_relationship.py
+++ b/sempyro/dcat/dcat_relationship.py
@@ -25,7 +25,7 @@ class Relationship(RDFModel):
             "$ontology": "https://www.w3.org/TR/vocab-dcat-3/",
             "$namespace": str(DCAT),
             "$IRI": DCAT.Relationship,
-            "$prefix": "prov"
+            "$prefix": "dcat"
         }
     )
 

--- a/sempyro/dcat/dcat_relationship.py
+++ b/sempyro/dcat/dcat_relationship.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Stichting Health-RI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+from typing import List
+
+from pydantic import ConfigDict, AnyHttpUrl, Field
+from rdflib.namespace import DCAT, DCTERMS
+
+from sempyro import RDFModel
+
+class Relationship(RDFModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "$ontology": "https://www.w3.org/TR/vocab-dcat-3/",
+            "$namespace": str(DCAT),
+            "$IRI": DCAT.Relationship,
+            "$prefix": "prov"
+        }
+    )
+
+    had_role: List[AnyHttpUrl] = Field(
+        description="The function of an entity or agent with respect to another entity or resource.",
+        json_schema_extra={
+            "rdf_term": DCAT.hadRole,
+            "rdf_type": "uri"
+        }
+    )
+    relation: List[AnyHttpUrl] = Field(
+        description="A related resource.",
+        json_schema_extra={
+            "rdf_term": DCTERMS.relation,
+            "rdf_type": "uri"
+        }
+    )
+
+
+if __name__ == "__main__":
+    json_models_folder = Path(Path(__file__).parents[2].resolve(), "models", "dcat")
+    Relationship.save_schema_to_file(path=Path(json_models_folder, "Relationship.json"), file_format="json")
+    Relationship.save_schema_to_file(path=Path(json_models_folder, "Relationship.yaml"), file_format="yaml")

--- a/sempyro/dqv/__init__.py
+++ b/sempyro/dqv/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Stichting Health-RI
+# Copyright 2025 Stichting Health-RI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,32 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from .quality_certificate import QualityCertificate
 
-from importlib.metadata import version
-
-from .rdf_model import LiteralField, RDFModel
-from .utils import validator_functions
-
-__version__ = version("sempyro")
-
-__all__ = (
-    "LiteralField",
-    "RDFModel",
-    "adms",
-    "dcat",
-    "dqv",
-    "foaf",
-    "geo",
-    "hri_dcat",
-    "namespaces",
-    "odrl",
-    "prov",
-    "spdx",
-    "time",
-    "vcard",
-    "validator_functions"
-    )
-
-
-def __dir__() -> "list[str]":
-    return list(__all__)
+__all__ = [
+    "QualityCertificate"
+]

--- a/sempyro/dqv/quality_certificate.py
+++ b/sempyro/dqv/quality_certificate.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Stichting Health-RI
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+from pydantic import ConfigDict, AnyHttpUrl, Field
+
+from sempyro import RDFModel
+from sempyro.namespaces import DQV, OA
+
+
+class QualityCertificate(RDFModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "$ontology": "https://www.w3.org/TR/vocab-dqv/",
+            "$namespace": str(DQV),
+            "$IRI": DQV.QualityCertificate,
+            "$prefix": "dqv"
+        }
+    )
+
+    target: AnyHttpUrl = Field(
+        default=None,
+        description="The relationship between an Annotation and its Target.",
+        json_schema_extra={
+            "rdf_term": OA.hasTarget,
+            "rdf_type": "uri"
+        }
+    )
+    body: AnyHttpUrl = Field(
+        default=None,
+        description="The object of the relationship is a resource that is a body of the Annotation.",
+        json_schema_extra={
+            "rdf_term": OA.hasBody,
+            "rdf_type": "uri"
+        }
+    )
+
+
+if __name__ == "__main__":
+    json_models_folder = Path(Path(__file__).parents[2].resolve(), "models", "dqv")
+    QualityCertificate.save_schema_to_file(path=Path(json_models_folder, "QualityCertificate.json"), file_format="json")
+    QualityCertificate.save_schema_to_file(path=Path(json_models_folder, "QualityCertificate.yaml"), file_format="yaml")

--- a/sempyro/hri_dcat/hri_dataset.py
+++ b/sempyro/hri_dcat/hri_dataset.py
@@ -16,10 +16,11 @@ from pathlib import Path
 from typing import List, Union
 
 from pydantic import AnyHttpUrl, ConfigDict, Field, field_validator
-from rdflib.namespace import DCAT, DCTERMS, FOAF
+from rdflib.namespace import DCAT, DCTERMS, FOAF, PROV
 
 from sempyro import LiteralField
-from sempyro.dcat import DCATDataset, AccessRights, DCATDistribution, DCATDatasetSeries
+from sempyro.dcat import DCATDataset, AccessRights, DCATDistribution, DCATDatasetSeries, Attribution
+from sempyro.dqv import QualityCertificate
 from sempyro.hri_dcat.hri_agent import HRIAgent
 from sempyro.hri_dcat.hri_vcard import HRIVCard
 from sempyro.hri_dcat.vocabularies import DatasetTheme, DatasetStatus
@@ -245,15 +246,14 @@ class HRIDataset(DCATDataset):
         }
     )
 
-    # TODO: Commented out due to Attribution in other branch
-    # qualified_attribution: List[Union[AnyHttpUrl, Attribution]] = Field(
-    #     default=None,
-    #     description="Attribution is the ascribing of an entity to an agent.",
-    #     json_schema_extra={
-    #         "rdf_term": PROV.qualifiedAttribution,
-    #         "rdf_type": "uri"
-    #     }
-    # )
+    qualified_attribution: List[Union[AnyHttpUrl, Attribution]] = Field(
+        default=None,
+        description="Attribution is the ascribing of an entity to an agent.",
+        json_schema_extra={
+            "rdf_term": PROV.qualifiedAttribution,
+            "rdf_type": "uri"
+        }
+    )
 
     qualified_relation: List[AnyHttpUrl] = Field(
         default=None,
@@ -264,15 +264,14 @@ class HRIDataset(DCATDataset):
         }
     )
 
-    # TODO: Commented out due to QualityCertificate in other branch
-    # quality_annotation: List[Union[AnyHttpUrl, QualityCertificate]] = Field(
-    #     default=None,
-    #     description="Refers to a quality annotation.",
-    #     json_schema_extra={
-    #         "rdf_term": DQV.hasQualityAnnotation,
-    #         "rdf_type": "uri"
-    #     }
-    # )
+    quality_annotation: List[Union[AnyHttpUrl, QualityCertificate]] = Field(
+        default=None,
+        description="Refers to a quality annotation.",
+        json_schema_extra={
+            "rdf_term": DQV.hasQualityAnnotation,
+            "rdf_type": "uri"
+        }
+    )
 
     retention_period: PeriodOfTime = Field(
         default=None,

--- a/sempyro/hri_dcat/hri_dataset_series.py
+++ b/sempyro/hri_dcat/hri_dataset_series.py
@@ -19,7 +19,7 @@ from rdflib import DCAT, DCTERMS
 
 from sempyro import LiteralField
 from sempyro.dcat import DCATDatasetSeries
-from sempyro.time import PeriodOfTime
+from sempyro.foaf import Agent
 from sempyro.vcard import VCard
 from sempyro.namespaces import DCATv3, DCATAPv3
 from sempyro.utils.validator_functions import force_literal_field
@@ -45,7 +45,6 @@ class HRIDatasetSeries(DCATDatasetSeries):
             "rdf_type": "uri"
         }
     )
-
     contact_point: List[Union[AnyHttpUrl, VCard]] = Field(
         default=None,
         description="Relevant contact information for the cataloged resource.",
@@ -54,23 +53,6 @@ class HRIDatasetSeries(DCATDatasetSeries):
             "rdf_type": "uri"
         }
     )
-
-    title: List[LiteralField] = Field(
-        description="A name given to the resource.",
-        json_schema_extra={
-            "rdf_term": DCTERMS.title,
-            "rdf_type": "rdfs_literal"
-        }
-    )
-
-    description: List[LiteralField] = Field(
-        description="An account of the resource.",
-        json_schema_extra={
-            "rdf_term": DCTERMS.description,
-            "rdf_type": "rdfs_literal"
-        }
-    )
-
     frequency: AnyHttpUrl = Field(
         default=None,
         description="The frequency with which items are added to a collection.",
@@ -79,21 +61,11 @@ class HRIDatasetSeries(DCATDatasetSeries):
             "rdf_type": "uri"
         }
     )
-
-    geographical_coverage: List[AnyHttpUrl] = Field(
+    publisher: Union[AnyHttpUrl, Agent] = Field(
         default=None,
-        description="Spatial characteristics of the resource.",
+        description="The entity responsible for making the resource available.",
         json_schema_extra={
-            "rdf_term": DCTERMS.spatial,
-            "rdf_type": "uri"
-        }
-    )
-
-    temporal_coverage: List[Union[AnyHttpUrl, PeriodOfTime]] = Field(
-        default=None,
-        description="Temporal characteristics of the resource.",
-        json_schema_extra={
-            "rdf_term": DCTERMS.temporal,
+            "rdf_term": DCTERMS.publisher,
             "rdf_type": "uri"
         }
     )

--- a/sempyro/hri_dcat/hri_dataset_series.py
+++ b/sempyro/hri_dcat/hri_dataset_series.py
@@ -14,12 +14,14 @@
 from pathlib import Path
 from typing import List, Union
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, AnyHttpUrl
 from rdflib import DCAT, DCTERMS
 
 from sempyro import LiteralField
 from sempyro.dcat import DCATDatasetSeries
-from sempyro.namespaces import DCATv3
+from sempyro.time import PeriodOfTime
+from sempyro.vcard import VCard
+from sempyro.namespaces import DCATv3, DCATAPv3
 from sempyro.utils.validator_functions import force_literal_field
 
 
@@ -32,6 +34,24 @@ class HRIDatasetSeries(DCATDatasetSeries):
             "$namespace": str(DCAT),
             "$IRI": DCATv3.DatasetSeries,
             "$prefix": "dcat"
+        }
+    )
+
+    applicable_legislation: List[AnyHttpUrl] = Field(
+        default=None,
+        description="The legislation that is applicable to this resource.",
+        json_schema_extra={
+            "rdf_term": DCATAPv3.applicableLegislation,
+            "rdf_type": "uri"
+        }
+    )
+
+    contact_point: List[Union[AnyHttpUrl, VCard]] = Field(
+        default=None,
+        description="Relevant contact information for the cataloged resource.",
+        json_schema_extra={
+            "rdf_term": DCAT.contactPoint,
+            "rdf_type": "uri"
         }
     )
 
@@ -48,6 +68,33 @@ class HRIDatasetSeries(DCATDatasetSeries):
         json_schema_extra={
             "rdf_term": DCTERMS.description,
             "rdf_type": "rdfs_literal"
+        }
+    )
+
+    frequency: AnyHttpUrl = Field(
+        default=None,
+        description="The frequency with which items are added to a collection.",
+        json_schema_extra={
+            "rdf_term": DCTERMS.accrualPeriodicity,
+            "rdf_type": "uri"
+        }
+    )
+
+    geographical_coverage: List[AnyHttpUrl] = Field(
+        default=None,
+        description="Spatial characteristics of the resource.",
+        json_schema_extra={
+            "rdf_term": DCTERMS.spatial,
+            "rdf_type": "uri"
+        }
+    )
+
+    temporal_coverage: List[Union[AnyHttpUrl, PeriodOfTime]] = Field(
+        default=None,
+        description="Temporal characteristics of the resource.",
+        json_schema_extra={
+            "rdf_term": DCTERMS.temporal,
+            "rdf_type": "uri"
         }
     )
 

--- a/sempyro/namespaces/DCATAPv3.py
+++ b/sempyro/namespaces/DCATAPv3.py
@@ -29,8 +29,8 @@ class DCATAPv3(DefinedNamespace):
     Date: 2025-04-30
     """
 
-    applicableLegislation: URIRef
+    applicableLegislation: URIRef # The legislation that is applicable to this resource.
+    availability: URIRef # An indication how long it is planned to keep the Distribution of the Dataset available.
+    hvdCategory: URIRef # A data category defined in the High Value Dataset Implementing Regulation.
 
     _NS = Namespace("http://data.europa.eu/r5r/")
-
-

--- a/sempyro/namespaces/OA.py
+++ b/sempyro/namespaces/OA.py
@@ -16,7 +16,7 @@ from rdflib.namespace import DefinedNamespace, Namespace
 
 
 class OA(DefinedNamespace):
-    hasTarget: URIRef
-    hasBody: URIRef
+    hasTarget: URIRef # The relationship between an Annotation and its Target.
+    hasBody: URIRef # The object of the relationship is a resource that is a body of the Annotation.
 
     _NS = Namespace("http://www.w3.org/ns/oa#")

--- a/sempyro/namespaces/OA.py
+++ b/sempyro/namespaces/OA.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Stichting Health-RI
+# Copyright 2025 Stichting Health-RI
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,32 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from importlib.metadata import version
-
-from .rdf_model import LiteralField, RDFModel
-from .utils import validator_functions
-
-__version__ = version("sempyro")
-
-__all__ = (
-    "LiteralField",
-    "RDFModel",
-    "adms",
-    "dcat",
-    "dqv",
-    "foaf",
-    "geo",
-    "hri_dcat",
-    "namespaces",
-    "odrl",
-    "prov",
-    "spdx",
-    "time",
-    "vcard",
-    "validator_functions"
-    )
+from rdflib import URIRef
+from rdflib.namespace import DefinedNamespace, Namespace
 
 
-def __dir__() -> "list[str]":
-    return list(__all__)
+class OA(DefinedNamespace):
+    hasTarget: URIRef
+    hasBody: URIRef
+
+    _NS = Namespace("http://www.w3.org/ns/oa#")

--- a/sempyro/namespaces/__init__.py
+++ b/sempyro/namespaces/__init__.py
@@ -23,6 +23,7 @@ from .DCATAPv3 import DCATAPv3
 from .HEALTHDCATAP import HEALTHDCATAP
 from .DPV import DPV
 from .DQV import DQV
+from .OA import OA
 
 __all__ = (
     "ADMS",
@@ -36,5 +37,6 @@ __all__ = (
     "DCATAPv3",
     "HEALTHDCATAP",
     "DPV",
-    "DQV"
+    "DQV",
+    "OA"
 )


### PR DESCRIPTION
## Summary by Sourcery

Integrate new provenance, quality and relationship constructs into DCAT-based schemas and models to enable standardized attribution, quality certification and resource linking.

New Features:
- Add prov:Attribution class with agent and role properties in JSON/YAML schemas and pydantic models
- Introduce dqv:QualityCertificate class to capture quality annotations with target and body in schemas and models
- Add dcat:Relationship class to represent resource relationships with hadRole and relation fields
- Re-enable qualified_attribution and quality_annotation fields in HRIDataset pydantic model
- Add applicableLegislation, frequency, contactPoint and publisher fields to HRIDatasetSeries model
- Publish new OA and DCATAPv3 namespace entries for annotation and legislation vocabularies

Enhancements:
- Allow attribution and quality annotation arrays to accept either URI strings or object references
- Extend schema definitions to support literal or structured fields for title, description and contactPoint
- Expand DCATAPv3 namespace with applicableLegislation, availability and hvdCategory terms