### PR TITLE
Adds Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to SeMPyRO
+
+Thank you for your interest in contributing to SeMPyRO! Your participation helps make this project better for everyone.
+
+All types of contributions are valued and appreciated, whether it's reporting bugs, suggesting features, improving documentation, or adding code.
+
+## Questions and Bug Reports
+
+If you have a question or encounter a bug, please file an Issue on our repository. When reporting bugs, include:
+
+- Clear steps to reproduce the issue
+- Relevant environment details (operating system, Python version)
+- SeMPyRO version you're using
+- Expected behavior versus actual behavior
+- Any error messages or logs
+
+## Guidelines for Adding Models
+
+See [Defining a model of your own and extending models](./docs/Defining_extending_a_model.md) for a tutorial on
+how to add and extend models. 
+When contributing new models to SeMPyRO, please follow these practices:
+
+### Inheritance and Properties
+
+- When subclassing existing models, reuse properties whenever possible
+- Only override properties when there's a meaningful technical difference (e.g., different cardinality or type)
+- Maintain consistent behavior patterns across related models
+
+Properties with a range that can refer to externally defined classes, e.g., the property `distribution` of a `DCATDataset`
+that has a range of `DCATDistribution`, should have the type `Union[AnyHttpUrl, DCATDistribution]`. This approach allows
+the `DCATDataset` class to be used by directly assigning the `DCATDistribution` class or by supplying the URI 
+for the Distribution class.
+
+If a property has the range `rdfs:Literal`, use the type `LiteralField` when a language tag might be
+supplied with this property. To support users providing values without defining a `LiteralField`,
+the property type should be defined as `Union[str, LiteralField]`.
+
+Properties with the range `rdfs:Literal` should have `rdf_type` in `json_schema_extra` equal to `rdfs_literal`, 
+`datetime_literal` or an `xsd` type. If the range is a URI, `rdf_type` should be `uri`.
+
+### Naming Conventions
+
+- Property names should match those in the application profile, not necessarily the RDF term
+- Example: For a Dataset in DCAT-AP v3, use `release_date` instead of `issued` (from `dct:issued`)
+- Replace spaces in property names with underscores (e.g., `access_rights` not `access rights`)
+
+### Namespaces and Vocabularies
+
+- If your model requires a namespace not already defined for the `rdf_term` in `json_schema_extra`, add it to `sempyro/namespaces`
+- Follow the existing namespace declaration patterns for consistency
+- Define vocabularies in a `vocabularies.py` file within your model's directory
+- Ensure vocabulary terms are properly documented and follow established patterns
+
+### Code Quality
+
+- Include appropriate tests for your model
+- Add documentation that explains the purpose and usage of your model
+- Follow the project's coding style and conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,9 @@ that has a range of `DCATDistribution`, should have the type `Union[AnyHttpUrl, 
 the `DCATDataset` class to be used by directly assigning the `DCATDistribution` class or by supplying the URI 
 for the Distribution class.
 
-If a property has the range `rdfs:Literal`, use the type `LiteralField` when a language tag might be
-supplied with this property. To support users providing values without defining a `LiteralField`,
-the property type should be defined as `Union[str, LiteralField]`.
+If a property has the range rdfs:Literal, and it may include a language tag (e.g., "text"@en), then its type should be 
+defined as LiteralField. However, to accommodate users who might provide a plain string without specifying a language 
+tag, the property should accept both types. Therefore, use the union type Union[str, LiteralField].
 
 Properties with the range `rdfs:Literal` should have `rdf_type` in `json_schema_extra` equal to `rdfs_literal`, 
 `datetime_literal` or an `xsd` type. If the range is a URI, `rdf_type` should be `uri`.

--- a/docs/Defining_extending_a_model.md
+++ b/docs/Defining_extending_a_model.md
@@ -20,20 +20,29 @@ from sempyro.time import DateTimeDescription
 from typing import Literal
 
 class CustomAgent(Agent):
-    name: str = Field(description="A name of the agent",
-                                                 rdf_term=FOAF.name,
-                                                 rdf_type="rdfs_literal"
-                                                 )
+    name: str = Field(
+        description="A name of the agent",
+        json_schema_extra={
+            "rdf_term": FOAF.name,
+            "rdf_type": "rdfs_literal"
+        }
+    )
+    
     birthday: DateTimeDescription = Field(
         description="The birthday of this Agent",
-        rdf_term=FOAF.birthday,
-        rdf_type="uri"
+        json_schema_extra={
+            "rdf_term": FOAF.birthday,
+            "rdf_type": "uri"
+        }
     )
+    
     gender: Literal["Male", "Female", "Other", "Ambiguous", "Unknown"] = Field(
         default=None,
         description="Gender as per Athena classification",
-        rdf_term=FOAF.gender,
-        rdf_type="xsd:string"
+        json_schema_extra={
+            "rdf_term": FOAF.gender,
+            "rdf_type": "xsd:string"
+        }
     )
 
 wizard = CustomAgent(name="Harry Potter",
@@ -112,15 +121,27 @@ class MagicWand(RDFModel):
                               }
                               )
     
-    magic_wand_wood: str = Field(description="Wood a magic wand is made of",
-                                 rdf_term=HPS.magic_wand_wood,
-                                 rdf_type="xsd:string")
-    magic_wand_core: str = Field(description="Core material of a magic wand",
-                                 rdf_term=HPS.magic_wand_core,
-                                 rdf_type="xsd:string")
-    magic_wand_length: float = Field(description="Magic wand length in inches",
-                                 rdf_term=HPS.magic_wand_length,
-                                 rdf_type="xsd:decimal")
+    magic_wand_wood: str = Field(
+        description="Wood a magic wand is made of",
+        json_schema_extra={
+            "rdf_term": HPS.magic_wand_wood,
+            "rdf_type": "xsd:string" 
+        }
+    )
+    magic_wand_core: str = Field(
+        description="Core material of a magic wand", 
+        json_schema_extra={
+            "rdf_term": HPS.magic_wand_core,
+            "rdf_type": "xsd:string"
+        }
+    )
+    magic_wand_length: float = Field(
+        description="Magic wand length in inches", 
+        json_schema_extra={
+            "rdf_term": HPS.magic_wand_length, 
+            "rdf_type": "xsd:decimal"
+        }
+    )
     # it is considered wands are rarely longer than 14 inches, it's add a validation and warning
     @field_validator("magic_wand_length", mode="before")
     @classmethod
@@ -150,26 +171,36 @@ class Wizard(Agent):
     animagus: bool = Field(
         default=False,
         description="Ability to turn to an animal",
-        rdf_term=HPS.animagus,
-        rdf_type="xsd:boolean"
+        json_schema_extra={
+            "rdf_term": HPS.animagus,
+            "rdf_type": "xsd:boolean"
+        }
     )
     wagic_wand: MagicWand = Field(
         description="Ability to turn to an animal",
-        rdf_term=HPS.magic_wand,
-        rdf_type="uri"
+        json_schema_extra={
+            "rdf_term": HPS.magic_wand,
+            "rdf_type": "uri"
+        }
     )
     patronus_form: str = Field(
         default=None,
         description="Form of patronus",
-        rdf_term=HPS.patronus_form,
-        rdf_type="xsd:string"
+        json_schema_extra={
+            "rdf_term": HPS.patronus_form,
+            "rdf_type": "xsd:string"
+        }
     )
     # For house we put a union of url type and RDFModel: it can be an external url as well as you can define a class 
     # House and then put its subject as an internal reference or put a whole object as a node. This notation can be used
     # when you are not sure or not care about the exact structure of the object
-    house: Union[AnyUrl, RDFModel] = Field(description="Hogwarts house",
-                                           rdf_term=HPS.hogwarts_house,
-                                           rdf_type="uri")
+    house: Union[AnyUrl, RDFModel] = Field(
+        description="Hogwarts house", 
+        json_schema_extra={
+            "rdf_term": HPS.hogwarts_house,
+            "rdf_type": "uri"
+        }
+    )
 ```
 Now let's create a Wizard class instance with Hermione Granger data:
 ```python

--- a/sempyro/hri_dcat/vocabularies.py
+++ b/sempyro/hri_dcat/vocabularies.py
@@ -58,6 +58,7 @@ class DatasetStatus(Enum):
     op_datpro = URIRef("http://publications.europa.eu/resource/authority/dataset-status/OP_DATPRO")
     discontinued = URIRef("http://publications.europa.eu/resource/authority/dataset-status/DISCONT")
 
+
 class DistributionStatus(Enum):
     develop = URIRef("http://publications.europa.eu/resource/authority/distribution-status/DEVELOP")
     completed = URIRef("http://publications.europa.eu/resource/authority/distribution-status/COMPLETED")


### PR DESCRIPTION
## Summary by Sourcery

Add contributing guidelines and update model definition docs to use json_schema_extra for RDF metadata

Documentation:
- Add CONTRIBUTING.md with guidelines for reporting issues, adding models, naming, namespaces, and code quality
- Update Defining_extending_a_model.md examples to use json_schema_extra for rdf_term and rdf_type metadata

Chores:
- Insert blank line before DistributionStatus enum in vocabularies.py for consistency