### PR TITLE
fix(ci): publish pypi on workflow dispatch, test on PR ready to review

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -1,8 +1,9 @@
 name: Build and Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
+  workflow_dispatch:
 
 env:
     PYTHON_VERSION: "3.12"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -6,6 +6,7 @@ name: Run tests for Python
 on:
   push:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 
 jobs:


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions CI triggers to use manual dispatch for PyPI publishing and broaden pull request event triggers for the Python test workflow

CI:
- Enable manual workflow_dispatch for PyPI publishing in publish_package.yml, replacing the release:published trigger
- Add opened, synchronize, reopened, and ready_for_review pull_request event types to the Python test workflow