### PR TITLE
Fix: HRIDistribution: byte_size: rdf_type

### DIFF
--- a/sempyro/hri_dcat/hri_distribution.py
+++ b/sempyro/hri_dcat/hri_distribution.py
@@ -118,7 +118,7 @@ class HRIDistribution(DCATDistribution):
         description="The size of a distribution in bytes.",
         json_schema_extra={
             "rdf_term": DCAT.byteSize,
-            "rdf_type": "xsd:integer"
+            "rdf_type": "xsd:nonNegativeInteger"
         }
     )
     applicable_legislation: List[AnyHttpUrl] = Field(


### PR DESCRIPTION
In the metadata schema and the SHACL byteSize is defined as xsd:nonNegativeInteger, this resulted in SHACL validation error when attempting to post a distribution to the FDP.

## Summary by Sourcery

Bug Fixes:
- Change byteSize rdf_type from xsd:integer to xsd:nonNegativeInteger to resolve SHACL validation errors