### PR TITLE
fix: wrong rdf_term for temporal_resolution

### DIFF
--- a/models/dcat/Attribution.yaml
+++ b/models/dcat/Attribution.yaml
@@ -27,8 +27,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -39,8 +39,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -57,7 +57,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -68,8 +68,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -97,15 +96,15 @@ properties:
       type: string
     - $ref: '#/$defs/Agent'
     default:
-    description: The prov:agent property references an prov:Agent which 
-      influenced a resource.
+    description: The prov:agent property references an prov:Agent which influenced
+      a resource.
     rdf_term: http://www.w3.org/ns/prov#agent
     rdf_type: uri
     title: Agent
   role:
     default:
-    description: The function of an entity or agent with respect to another 
-      entity or resource.
+    description: The function of an entity or agent with respect to another entity
+      or resource.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hadRole

--- a/models/dcat/DCATCatalog.yaml
+++ b/models/dcat/DCATCatalog.yaml
@@ -12,9 +12,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -25,11 +25,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -42,11 +41,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -56,22 +54,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -80,9 +76,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -93,9 +89,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -104,10 +100,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -118,12 +114,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -132,18 +127,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -154,12 +148,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -168,12 +161,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -181,8 +173,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -193,10 +185,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -207,10 +199,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -221,11 +213,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -261,8 +252,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -273,8 +264,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -299,8 +290,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -309,9 +300,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -320,11 +311,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -381,15 +371,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -400,8 +388,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -415,9 +403,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -441,8 +428,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -454,14 +441,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -472,8 +458,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -493,9 +479,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -511,17 +496,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -532,8 +515,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -549,17 +532,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -589,15 +570,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -635,15 +615,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -654,8 +633,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -684,8 +663,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -695,8 +674,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -710,8 +689,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -722,8 +701,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -732,8 +711,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -742,8 +721,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -809,8 +788,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -828,8 +807,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -842,8 +821,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -880,11 +859,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -893,9 +871,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -904,10 +882,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -916,9 +893,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -927,12 +904,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -940,11 +916,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -980,8 +955,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -993,8 +968,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1002,8 +977,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1012,27 +987,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1078,8 +1053,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -1088,8 +1062,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -1111,26 +1084,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -1147,8 +1119,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -1163,25 +1134,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -1191,8 +1161,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -1209,8 +1178,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -1232,7 +1201,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -1243,8 +1212,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -1276,8 +1244,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -1293,8 +1260,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -1348,8 +1314,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -1360,8 +1326,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -1394,8 +1360,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -1406,8 +1372,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -1418,9 +1384,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -1431,8 +1397,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -1511,8 +1477,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -1530,11 +1495,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1543,9 +1507,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1554,10 +1518,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1566,9 +1529,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1577,12 +1540,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1590,11 +1552,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1630,8 +1591,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -1639,8 +1599,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -1649,8 +1609,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -1667,15 +1626,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -1692,23 +1650,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1742,8 +1700,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -1776,15 +1734,13 @@ properties:
       type: string
     - type: 'null'
     default:
-    description: Information about who can access the dataset and under what 
-      conditions.
+    description: Information about who can access the dataset and under what conditions.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
     title: Access Rights
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     items:
       format: uri
       minLength: 1
@@ -1795,8 +1751,8 @@ properties:
     type: array
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - format: uri
@@ -1810,8 +1766,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -1835,8 +1791,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -1848,14 +1804,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -1866,8 +1821,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -1887,9 +1842,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -1911,10 +1865,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -1925,8 +1878,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -1942,10 +1894,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -1987,8 +1938,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -2026,15 +1976,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -2045,8 +1993,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -2075,8 +2023,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -2086,8 +2034,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -2101,8 +2049,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -2113,8 +2061,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -2123,8 +2071,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -2133,8 +2081,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -2200,8 +2148,7 @@ properties:
     type: array
   spatial_resolution:
     default:
-    description: Minimum spatial separation resolvable in a dataset, measured in
-      meters.
+    description: Minimum spatial separation resolvable in a dataset, measured in meters.
     items:
       type: number
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -2219,8 +2166,8 @@ properties:
     title: Temporal Resolution
   was_generated_by:
     default:
-    description: An activity that generated, or provides the business context 
-      for, the creation of the dataset.
+    description: An activity that generated, or provides the business context for,
+      the creation of the dataset.
     items:
       anyOf:
       - format: uri
@@ -2233,8 +2180,7 @@ properties:
     type: array
   applicable_legislation:
     default:
-    description: The legislation that mandates the creation or management of the
-      dataset.
+    description: The legislation that mandates the creation or management of the dataset.
     items:
       format: uri
       minLength: 1
@@ -2254,8 +2200,8 @@ properties:
     type: array
   catalog_record:
     default:
-    description: A record describing the registration of a single resource 
-      (e.g., a dataset, a data service) that is part of the catalog.
+    description: A record describing the registration of a single resource (e.g.,
+      a dataset, a data service) that is part of the catalog.
     items:
       anyOf:
       - format: uri
@@ -2303,8 +2249,8 @@ properties:
     type: array
   homepage:
     default:
-    description: A homepage of the catalog (a public Web document usually 
-      available in HTML).
+    description: A homepage of the catalog (a public Web document usually available
+      in HTML).
     format: uri
     minLength: 1
     rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2313,8 +2259,8 @@ properties:
     type: string
   themes:
     default:
-    description: A knowledge organization system (KOS) used to classify the 
-      resources documented in the catalog (e.g., datasets and services).
+    description: A knowledge organization system (KOS) used to classify the resources
+      documented in the catalog (e.g., datasets and services).
     items:
       format: uri
       minLength: 1

--- a/models/dcat/DCATDataService.yaml
+++ b/models/dcat/DCATDataService.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -354,15 +344,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -373,8 +361,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -388,9 +376,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -414,8 +401,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -427,14 +414,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -445,8 +431,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -466,9 +452,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -484,17 +469,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -505,8 +488,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -522,17 +505,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -562,15 +543,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -608,15 +588,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -627,8 +606,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -657,8 +636,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -668,8 +647,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -683,8 +662,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -695,8 +674,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -705,8 +684,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -715,8 +694,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -782,8 +761,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -801,8 +780,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -815,8 +794,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -850,14 +829,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -866,8 +844,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -881,9 +859,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -907,8 +884,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -920,14 +897,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -938,8 +914,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -959,9 +935,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -977,17 +952,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -998,8 +971,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1015,17 +988,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1055,15 +1026,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1101,15 +1071,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1120,8 +1089,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1150,8 +1119,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1161,8 +1130,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1176,8 +1145,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1188,8 +1157,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1198,8 +1167,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1208,8 +1177,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1259,11 +1228,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1272,9 +1240,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1283,10 +1251,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1295,9 +1262,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1306,12 +1273,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1319,11 +1285,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1359,8 +1324,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1372,8 +1337,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1381,8 +1346,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1391,27 +1356,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1457,8 +1422,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -1467,8 +1431,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -1490,26 +1453,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -1526,8 +1488,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -1542,25 +1503,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -1570,8 +1530,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -1588,8 +1547,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -1611,7 +1570,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -1622,8 +1581,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -1655,8 +1613,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -1672,8 +1629,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -1727,8 +1683,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -1739,8 +1695,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -1773,8 +1729,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -1785,8 +1741,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -1797,9 +1753,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -1810,8 +1766,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -1890,8 +1846,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -1909,11 +1864,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1922,9 +1876,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1933,10 +1887,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1945,9 +1898,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1956,12 +1909,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1969,11 +1921,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -2009,8 +1960,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -2018,8 +1968,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -2028,8 +1978,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -2046,15 +1995,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -2071,23 +2019,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -2121,8 +2069,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -2146,20 +2094,19 @@ $namespace: http://www.w3.org/ns/dcat#
 $ontology: https://www.w3.org/TR/vocab-dcat-3/
 $prefix: dcat
 additionalProperties: false
-description: A collection of operations that provides access to one or more 
-  datasets or data processing functions.
+description: A collection of operations that provides access to one or more datasets
+  or data processing functions.
 properties:
   access_rights:
     $ref: '#/$defs/AccessRights'
     default:
-    description: Information about who can access the resource or an indication 
-      of its security status.
+    description: Information about who can access the resource or an indication of
+      its security status.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/conformsTo
@@ -2168,8 +2115,8 @@ properties:
     type: string
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - format: uri
@@ -2183,8 +2130,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -2208,8 +2155,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -2221,14 +2168,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -2239,8 +2185,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -2260,9 +2206,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -2284,10 +2229,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -2298,8 +2242,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -2315,10 +2258,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -2360,8 +2302,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -2399,15 +2340,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -2418,8 +2357,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -2448,8 +2387,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -2459,8 +2398,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -2474,8 +2413,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -2486,8 +2425,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -2496,8 +2435,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -2506,8 +2445,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -2540,8 +2479,8 @@ properties:
     type: array
   endpoint_description:
     default:
-    description: A description of the services available via the end-points, 
-      including their operations, parameters etc.
+    description: A description of the services available via the end-points, including
+      their operations, parameters etc.
     items:
       anyOf:
       - format: uri
@@ -2553,8 +2492,8 @@ properties:
     title: Endpoint Description
     type: array
   endpoint_url:
-    description: The root location or primary endpoint of the service (a 
-      Web-resolvable IRI).
+    description: The root location or primary endpoint of the service (a Web-resolvable
+      IRI).
     items:
       anyOf:
       - format: uri

--- a/models/dcat/DCATDataset.yaml
+++ b/models/dcat/DCATDataset.yaml
@@ -12,9 +12,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -25,11 +25,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -42,11 +41,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -56,22 +54,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -80,9 +76,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -93,9 +89,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -104,10 +100,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -118,12 +114,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -132,18 +127,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -154,12 +148,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -168,12 +161,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -181,8 +173,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -193,10 +185,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -207,10 +199,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -221,11 +213,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -261,8 +252,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -273,8 +264,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -299,8 +290,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -309,9 +300,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -320,11 +311,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -347,11 +337,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -360,9 +349,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -371,10 +360,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -383,9 +371,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -394,12 +382,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -407,11 +394,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -447,8 +433,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -460,8 +446,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -469,8 +455,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -479,27 +465,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -545,8 +531,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -555,8 +540,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -578,26 +562,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -614,8 +597,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -630,25 +612,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -658,8 +639,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -676,8 +656,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -699,7 +679,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -710,8 +690,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -743,8 +722,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -760,8 +738,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -815,8 +792,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -827,8 +804,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -861,8 +838,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -873,8 +850,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -885,9 +862,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -898,8 +875,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -978,8 +955,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -997,11 +973,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1010,9 +985,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1021,10 +996,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1033,9 +1007,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1044,12 +1018,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1057,11 +1030,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1097,8 +1069,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -1106,8 +1077,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -1116,8 +1087,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -1134,15 +1104,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -1159,23 +1128,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1209,8 +1178,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -1242,15 +1211,13 @@ properties:
       type: string
     - type: 'null'
     default:
-    description: Information about who can access the dataset and under what 
-      conditions.
+    description: Information about who can access the dataset and under what conditions.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
     title: Access Rights
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     items:
       format: uri
       minLength: 1
@@ -1261,8 +1228,8 @@ properties:
     type: array
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - format: uri
@@ -1276,8 +1243,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -1301,8 +1268,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -1314,14 +1281,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -1332,8 +1298,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -1353,9 +1319,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -1377,10 +1342,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -1391,8 +1355,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -1408,10 +1371,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -1453,8 +1415,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -1492,15 +1453,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -1511,8 +1470,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1541,8 +1500,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -1552,8 +1511,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -1567,8 +1526,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -1579,8 +1538,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -1589,8 +1548,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -1599,8 +1558,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -1666,8 +1625,7 @@ properties:
     type: array
   spatial_resolution:
     default:
-    description: Minimum spatial separation resolvable in a dataset, measured in
-      meters.
+    description: Minimum spatial separation resolvable in a dataset, measured in meters.
     items:
       type: number
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -1685,8 +1643,8 @@ properties:
     title: Temporal Resolution
   was_generated_by:
     default:
-    description: An activity that generated, or provides the business context 
-      for, the creation of the dataset.
+    description: An activity that generated, or provides the business context for,
+      the creation of the dataset.
     items:
       anyOf:
       - format: uri
@@ -1699,8 +1657,7 @@ properties:
     type: array
   applicable_legislation:
     default:
-    description: The legislation that mandates the creation or management of the
-      dataset.
+    description: The legislation that mandates the creation or management of the dataset.
     items:
       format: uri
       minLength: 1

--- a/models/dcat/DCATDatasetSeries.yaml
+++ b/models/dcat/DCATDatasetSeries.yaml
@@ -34,8 +34,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -46,8 +46,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -65,8 +65,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -78,8 +78,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -87,8 +87,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -97,27 +97,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -163,8 +163,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -173,8 +172,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -196,26 +194,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -232,8 +229,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -248,25 +244,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -276,8 +271,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -288,7 +282,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -299,8 +293,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -332,8 +325,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -349,8 +341,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -404,8 +395,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -416,8 +407,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -450,8 +441,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -462,8 +453,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -474,9 +465,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -487,8 +478,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -567,8 +558,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -599,8 +589,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -608,8 +597,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -618,8 +607,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -636,15 +624,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -661,23 +648,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -711,8 +698,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -736,20 +723,19 @@ $namespace: http://www.w3.org/ns/dcat#
 $ontology: https://www.w3.org/TR/vocab-dcat-3/
 $prefix: dcat
 additionalProperties: false
-description: A collection of datasets that are published separately, but share 
-  some characteristics that group them
+description: A collection of datasets that are published separately, but share some
+  characteristics that group them
 properties:
   access_rights:
     $ref: '#/$defs/AccessRights'
     default:
-    description: Information about who can access the resource or an indication 
-      of its security status.
+    description: Information about who can access the resource or an indication of
+      its security status.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/conformsTo
@@ -758,8 +744,8 @@ properties:
     type: string
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - format: uri
@@ -773,8 +759,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -798,8 +784,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -811,14 +797,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -829,8 +814,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -850,9 +835,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -874,10 +858,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -888,8 +871,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -905,10 +887,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -950,8 +931,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -989,15 +969,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -1008,8 +986,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1038,8 +1016,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -1049,8 +1027,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -1064,8 +1042,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -1076,8 +1054,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -1086,8 +1064,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -1096,8 +1074,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1

--- a/models/dcat/DCATDistribution.json
+++ b/models/dcat/DCATDistribution.json
@@ -3229,7 +3229,7 @@
       ],
       "default": null,
       "description": "Minimum time period resolvable in the dataset.",
-      "rdf_term": "http://www.w3.org/ns/dcat#spatialResolutionInMeters",
+      "rdf_term": "http://www.w3.org/ns/dcat#temporalResolution",
       "rdf_type": "xsd:duration",
       "title": "Temporal Resolution"
     },

--- a/models/dcat/DCATDistribution.yaml
+++ b/models/dcat/DCATDistribution.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -346,10 +336,10 @@ $defs:
     $ontology: http://spdx.org/rdf/terms/2.3
     $prefix: spdx
     additionalProperties: false
-    description: "A Checksum is value that allows the contents of a file to be authenticated.\
-      \ \nEven small changes to the content of the file will change its checksum.\
-      \ \nThis class allows the results of a variety of checksum and cryptographic
-      message digest algorithms to be \nrepresented."
+    description: "A Checksum is value that allows the contents of a file to be authenticated.
+      \nEven small changes to the content of the file will change its checksum. \n
+      This class allows the results of a variety of checksum and cryptographic message
+      digest algorithms to be \nrepresented."
     properties:
       algorithm:
         description: The algorithm used to produce the subject Checksum.
@@ -363,8 +353,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A lower case hexadecimal encoded digest value produced 
-          using a specific algorithm.
+        description: A lower case hexadecimal encoded digest value produced using
+          a specific algorithm.
         rdf_term: http://spdx.org/rdf/terms#checksumValue
         rdf_type: xsd:hexBinary
         title: Checksum Value
@@ -379,20 +369,19 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -401,8 +390,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -416,9 +405,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -442,8 +430,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -455,14 +443,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -473,8 +460,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -494,9 +481,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -512,17 +498,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -533,8 +517,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -550,17 +534,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -590,15 +572,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -636,15 +617,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -655,8 +635,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -685,8 +665,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -696,8 +676,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -711,8 +691,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -723,8 +703,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -733,8 +713,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -743,8 +723,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -777,8 +757,8 @@ $defs:
         type: array
       endpoint_description:
         default:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         items:
           anyOf:
           - format: uri
@@ -790,8 +770,8 @@ $defs:
         title: Endpoint Description
         type: array
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         items:
           anyOf:
           - format: uri
@@ -835,15 +815,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -854,8 +832,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -869,9 +847,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -895,8 +872,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -908,14 +885,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -926,8 +902,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -947,9 +923,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -965,17 +940,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -986,8 +959,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1003,17 +976,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1043,15 +1014,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1089,15 +1059,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1108,8 +1077,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1138,8 +1107,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1149,8 +1118,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1164,8 +1133,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1176,8 +1145,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1186,8 +1155,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1196,8 +1165,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1263,8 +1232,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -1282,8 +1251,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -1296,8 +1265,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -1331,14 +1300,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -1347,8 +1315,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -1362,9 +1330,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -1388,8 +1355,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -1401,14 +1368,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -1419,8 +1385,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -1440,9 +1406,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -1458,17 +1423,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1479,8 +1442,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1496,17 +1459,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1536,15 +1497,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1582,15 +1542,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1601,8 +1560,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1631,8 +1590,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1642,8 +1601,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1657,8 +1616,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1669,8 +1628,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1679,8 +1638,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1689,8 +1648,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1740,11 +1699,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1753,9 +1711,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1764,10 +1722,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1776,9 +1733,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1787,12 +1744,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1800,11 +1756,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1840,8 +1795,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1853,8 +1808,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1862,8 +1817,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1872,27 +1827,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1938,8 +1893,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -1948,8 +1902,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -1971,26 +1924,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -2007,8 +1959,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -2023,25 +1974,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -2051,8 +2001,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -2069,8 +2018,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -2092,7 +2041,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -2103,8 +2052,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -2136,8 +2084,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -2153,8 +2100,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -2208,8 +2154,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -2220,8 +2166,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -2254,8 +2200,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -2266,8 +2212,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -2278,9 +2224,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -2291,8 +2237,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -2371,8 +2317,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -2390,11 +2335,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -2403,9 +2347,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -2414,10 +2358,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -2426,9 +2369,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -2437,12 +2380,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -2450,11 +2392,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -2490,8 +2431,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -2499,8 +2439,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -2509,8 +2449,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -2527,15 +2466,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -2552,23 +2490,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -2602,8 +2540,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -2655,8 +2593,7 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Date of formal issuance (e.g., publication) of the 
-      distribution.
+    description: Date of formal issuance (e.g., publication) of the distribution.
     rdf_term: http://purl.org/dc/terms/issued
     rdf_type: datetime_literal
     title: Release Date
@@ -2668,15 +2605,14 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the distribution was changed, updated
-      or modified.
+    description: Most recent date on which the distribution was changed, updated or
+      modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   license:
     default:
-    description: A legal document under which the distribution is made 
-      available.
+    description: A legal document under which the distribution is made available.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/license
@@ -2685,8 +2621,7 @@ properties:
     type: string
   access_rights:
     default:
-    description: A rights statement that concerns how the distribution is 
-      accessed.
+    description: A rights statement that concerns how the distribution is accessed.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/accessRights
@@ -2707,13 +2642,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the distribution.
+    description: An ODRL conformant policy expressing the rights associated with the
+      distribution.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   access_url:
-    description: A URL of the resource that gives access to a distribution of 
-      the dataset. E.g., landing page, feed, SPARQL endpoint.
+    description: A URL of the resource that gives access to a distribution of the
+      dataset. E.g., landing page, feed, SPARQL endpoint.
     items:
       format: uri
       minLength: 1
@@ -2724,8 +2659,7 @@ properties:
     type: array
   access_service:
     default:
-    description: A data service that gives access to the distribution of the 
-      dataset
+    description: A data service that gives access to the distribution of the dataset
     items:
       anyOf:
       - format: uri
@@ -2738,9 +2672,9 @@ properties:
     type: array
   download_url:
     default:
-    description: The URL of the downloadable file in a given format. E.g., CSV 
-      file or RDF file. The format is indicated by the distribution's 
-      dcterms:format and/or dcat:mediaType
+    description: The URL of the downloadable file in a given format. E.g., CSV file
+      or RDF file. The format is indicated by the distribution's dcterms:format and/or
+      dcat:mediaType
     items:
       format: uri
       minLength: 1
@@ -2763,8 +2697,8 @@ properties:
     - type: number
     - $ref: '#/$defs/LiteralField'
     default:
-    description: Minimum spatial separation resolvable in a dataset 
-      distribution, measured in meters.
+    description: Minimum spatial separation resolvable in a dataset distribution,
+      measured in meters.
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
     rdf_type: xsd:decimal
     title: Spatial Resolution
@@ -2774,7 +2708,7 @@ properties:
     - $ref: '#/$defs/LiteralField'
     default:
     description: Minimum time period resolvable in the dataset.
-    rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
+    rdf_term: http://www.w3.org/ns/dcat#temporalResolution
     rdf_type: xsd:duration
     title: Temporal Resolution
   conforms_to:
@@ -2808,9 +2742,8 @@ properties:
     type: string
   compression_format:
     default:
-    description: The compression format of the distribution in which the data is
-      contained in a compressed form, e.g., to reduce the size of the 
-      downloadable file.
+    description: The compression format of the distribution in which the data is contained
+      in a compressed form, e.g., to reduce the size of the downloadable file.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#compressFormat
@@ -2819,9 +2752,9 @@ properties:
     type: string
   packaging_format:
     default:
-    description: The package format of the distribution in which one or more 
-      data files are grouped together, e.g., to enable a set of related files to
-      be downloaded together.
+    description: The package format of the distribution in which one or more data
+      files are grouped together, e.g., to enable a set of related files to be downloaded
+      together.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#packageFormat
@@ -2831,8 +2764,8 @@ properties:
   checksum:
     $ref: '#/$defs/Checksum'
     default:
-    description: The checksum property provides a mechanism that can be used to 
-      verify that the contents of a file or package have not changed [SPDX].
+    description: The checksum property provides a mechanism that can be used to verify
+      that the contents of a file or package have not changed [SPDX].
     rdf_term: http://spdx.org/rdf/terms#checksum
     rdf_type: uri
 required:

--- a/models/dcat/DCATResource.yaml
+++ b/models/dcat/DCATResource.yaml
@@ -34,8 +34,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -46,8 +46,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -65,8 +65,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -78,8 +78,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -87,8 +87,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -97,27 +97,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -163,8 +163,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -173,8 +172,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -196,26 +194,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -232,8 +229,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -248,25 +244,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -276,8 +271,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -288,7 +282,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -299,8 +293,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -332,8 +325,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -349,8 +341,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -404,8 +395,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -416,8 +407,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -450,8 +441,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -462,8 +453,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -474,9 +465,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -487,8 +478,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -567,8 +558,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -599,8 +589,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -608,8 +597,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -618,8 +607,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -636,15 +624,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -661,23 +648,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -711,8 +698,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -741,14 +728,13 @@ properties:
   access_rights:
     $ref: '#/$defs/AccessRights'
     default:
-    description: Information about who can access the resource or an indication 
-      of its security status.
+    description: Information about who can access the resource or an indication of
+      its security status.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/conformsTo
@@ -757,8 +743,8 @@ properties:
     type: string
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - format: uri
@@ -772,8 +758,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -797,8 +783,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -810,14 +796,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -828,8 +813,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -849,9 +834,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -873,10 +857,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -887,8 +870,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -904,10 +886,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -949,8 +930,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -988,15 +968,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -1007,8 +985,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1037,8 +1015,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -1048,8 +1026,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -1063,8 +1041,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -1075,8 +1053,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -1085,8 +1063,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -1095,8 +1073,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1

--- a/models/dcat/Relationship.yaml
+++ b/models/dcat/Relationship.yaml
@@ -5,8 +5,8 @@ $prefix: dcat
 additionalProperties: false
 properties:
   had_role:
-    description: The function of an entity or agent with respect to another 
-      entity or resource.
+    description: The function of an entity or agent with respect to another entity
+      or resource.
     items:
       format: uri
       minLength: 1

--- a/models/foaf/Agent.yaml
+++ b/models/foaf/Agent.yaml
@@ -5,7 +5,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -16,8 +16,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -58,8 +57,8 @@ properties:
     title: Identifier
   mbox:
     default:
-    description: A personal mailbox, ie. an Internet mailbox associated with 
-      exactly one owner, the first owner of this mailbox.
+    description: A personal mailbox, ie. an Internet mailbox associated with exactly
+      one owner, the first owner of this mailbox.
     items:
       format: uri
       minLength: 1
@@ -70,8 +69,8 @@ properties:
     type: array
   homepage:
     default:
-    description: A webpage that either allows to make contact (i.e. a webform) 
-      or the information contains how to get into contact.
+    description: A webpage that either allows to make contact (i.e. a webform) or
+      the information contains how to get into contact.
     format: uri
     minLength: 1
     rdf_term: http://xmlns.com/foaf/0.1/homepage

--- a/models/foaf/Project.yaml
+++ b/models/foaf/Project.yaml
@@ -27,8 +27,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -39,8 +39,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -57,7 +57,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -68,8 +68,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -104,8 +103,7 @@ properties:
     anyOf:
     - type: string
     - $ref: '#/$defs/LiteralField'
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     rdf_term: http://purl.org/dc/terms/identifier
     rdf_type: xsd:string
     title: Identifier

--- a/models/geo/Geometry.yaml
+++ b/models/geo/Geometry.yaml
@@ -5,7 +5,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -16,8 +16,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -41,26 +40,25 @@ description: Geometry class for GeoSPARQL Geometry specification
 properties:
   dimension:
     default:
-    description: The topological dimension of this geometric object, which must 
-      be less than or equal to the coordinate dimension. In non-homogeneous 
-      collections, this is the largest topological dimension of the contained 
-      objects.
+    description: The topological dimension of this geometric object, which must be
+      less than or equal to the coordinate dimension. In non-homogeneous collections,
+      this is the largest topological dimension of the contained objects.
     rdf_term: http://www.opengis.net/ont/geosparql#dimension
     rdf_type: xsd:integer
     title: Dimension
     type: integer
   coordinateDimension:
     default:
-    description: The number of measurements or axes needed to describe the 
-      position of this Geometry in a coordinate system.
+    description: The number of measurements or axes needed to describe the position
+      of this Geometry in a coordinate system.
     rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
     rdf_type: xsd:integer
     title: Coordinatedimension
     type: integer
   spatialDimension:
     default:
-    description: The number of measurements or axes needed to describe the 
-      spatial position of this Geometry in a coordinate system.
+    description: The number of measurements or axes needed to describe the spatial
+      position of this Geometry in a coordinate system.
     rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
     rdf_type: xsd:integer
     title: Spatialdimension
@@ -92,25 +90,23 @@ properties:
     type: string
   hasMetricSpatialAccuracy:
     default:
-    description: The positional accuracy of the coordinates of a Geometry in 
-      meters.
+    description: The positional accuracy of the coordinates of a Geometry in meters.
     rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
     rdf_type: xsd:double
     title: Hasmetricspatialaccuracy
     type: number
   isEmpty:
     default:
-    description: (true) if this geometric object is the empty Geometry. If true,
-      then this geometric object represents the empty point set for the 
-      coordinate space.
+    description: (true) if this geometric object is the empty Geometry. If true, then
+      this geometric object represents the empty point set for the coordinate space.
     rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
     rdf_type: xsd:boolean
     title: Isempty
     type: boolean
   isSimple:
     default:
-    description: (true) if this geometric object has no anomalous geometric 
-      points, such as self intersection or self tangency.
+    description: (true) if this geometric object has no anomalous geometric points,
+      such as self intersection or self tangency.
     rdf_term: http://www.opengis.net/ont/geosparql#isSimple
     rdf_type: xsd:boolean
     title: Issimple

--- a/models/geo/Location.yaml
+++ b/models/geo/Location.yaml
@@ -10,26 +10,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -46,8 +45,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -62,25 +60,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -90,8 +87,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -102,7 +98,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -113,8 +109,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -144,8 +139,7 @@ properties:
     - locn
     - http://www.w3.org/ns/locn#
     default:
-    description: Associates a spatial thing [SDW-BP] with a corresponding 
-      geometry.
+    description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
     rdf_term: http://www.w3.org/ns/locn#geometry
     rdf_type: geosparql:wktLiteral
     title: Geometry

--- a/models/health_dcat/HEALTHDCATAPAgent.yaml
+++ b/models/health_dcat/HEALTHDCATAPAgent.yaml
@@ -5,7 +5,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -16,8 +16,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -60,8 +59,8 @@ properties:
     title: Identifier
   mbox:
     default:
-    description: A personal mailbox, ie. an Internet mailbox associated with 
-      exactly one owner, the first owner of this mailbox.
+    description: A personal mailbox, ie. an Internet mailbox associated with exactly
+      one owner, the first owner of this mailbox.
     items:
       format: uri
       minLength: 1
@@ -72,8 +71,8 @@ properties:
     type: array
   homepage:
     default:
-    description: A webpage that either allows to make contact (i.e. a webform) 
-      or the information contains how to get into contact.
+    description: A webpage that either allows to make contact (i.e. a webform) or
+      the information contains how to get into contact.
     format: uri
     minLength: 1
     rdf_term: http://xmlns.com/foaf/0.1/homepage

--- a/models/health_dcat/HEALTHDCATAPCatalog.yaml
+++ b/models/health_dcat/HEALTHDCATAPCatalog.yaml
@@ -12,9 +12,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -25,11 +25,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -42,11 +41,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -56,22 +54,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -80,9 +76,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -93,9 +89,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -104,10 +100,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -118,12 +114,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -132,18 +127,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -154,12 +148,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -168,12 +161,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -181,8 +173,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -193,10 +185,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -207,10 +199,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -221,11 +213,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -261,8 +252,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -273,8 +264,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -299,8 +290,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -309,9 +300,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -320,11 +311,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -381,15 +371,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -400,8 +388,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -415,9 +403,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -441,8 +428,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -454,14 +441,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -472,8 +458,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -493,9 +479,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -511,17 +496,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -532,8 +515,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -549,17 +532,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -589,15 +570,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -635,15 +615,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -654,8 +633,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -684,8 +663,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -695,8 +674,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -710,8 +689,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -722,8 +701,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -732,8 +711,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -742,8 +721,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -809,8 +788,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -828,8 +807,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -842,8 +821,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -880,11 +859,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -893,9 +871,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -904,10 +882,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -916,9 +893,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -927,12 +904,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -940,11 +916,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -980,8 +955,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -993,8 +968,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1002,8 +977,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1012,27 +987,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1078,8 +1053,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -1088,8 +1062,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -1111,26 +1084,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -1147,8 +1119,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -1163,25 +1134,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -1191,8 +1161,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -1209,8 +1178,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -1232,7 +1201,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -1243,8 +1212,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -1276,8 +1244,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -1293,8 +1260,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -1348,8 +1314,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -1360,8 +1326,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -1394,8 +1360,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -1406,8 +1372,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -1418,9 +1384,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -1431,8 +1397,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -1511,8 +1477,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -1530,11 +1495,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1543,9 +1507,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1554,10 +1518,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1566,9 +1529,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1577,12 +1540,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1590,11 +1552,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1630,8 +1591,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -1639,8 +1599,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -1649,8 +1609,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -1667,15 +1626,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -1692,23 +1650,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1742,8 +1700,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -1777,15 +1735,13 @@ properties:
       type: string
     - type: 'null'
     default:
-    description: Information about who can access the dataset and under what 
-      conditions.
+    description: Information about who can access the dataset and under what conditions.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
     title: Access Rights
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     items:
       format: uri
       minLength: 1
@@ -1796,8 +1752,8 @@ properties:
     type: array
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - format: uri
@@ -1811,8 +1767,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -1836,8 +1792,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -1849,14 +1805,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -1867,8 +1822,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -1888,9 +1843,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -1912,10 +1866,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -1926,8 +1879,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -1943,10 +1895,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -1988,8 +1939,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -2027,15 +1977,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -2046,8 +1994,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -2076,8 +2024,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -2087,8 +2035,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -2102,8 +2050,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -2114,8 +2062,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -2124,8 +2072,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -2134,8 +2082,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -2201,8 +2149,7 @@ properties:
     type: array
   spatial_resolution:
     default:
-    description: Minimum spatial separation resolvable in a dataset, measured in
-      meters.
+    description: Minimum spatial separation resolvable in a dataset, measured in meters.
     items:
       type: number
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -2220,8 +2167,8 @@ properties:
     title: Temporal Resolution
   was_generated_by:
     default:
-    description: An activity that generated, or provides the business context 
-      for, the creation of the dataset.
+    description: An activity that generated, or provides the business context for,
+      the creation of the dataset.
     items:
       anyOf:
       - format: uri
@@ -2234,8 +2181,7 @@ properties:
     type: array
   applicable_legislation:
     default:
-    description: The legislation that mandates the creation or management of the
-      dataset.
+    description: The legislation that mandates the creation or management of the dataset.
     items:
       format: uri
       minLength: 1
@@ -2255,8 +2201,8 @@ properties:
     type: array
   catalog_record:
     default:
-    description: A record describing the registration of a single resource 
-      (e.g., a dataset, a data service) that is part of the catalog.
+    description: A record describing the registration of a single resource (e.g.,
+      a dataset, a data service) that is part of the catalog.
     items:
       anyOf:
       - format: uri
@@ -2304,8 +2250,8 @@ properties:
     type: array
   homepage:
     default:
-    description: A homepage of the catalog (a public Web document usually 
-      available in HTML).
+    description: A homepage of the catalog (a public Web document usually available
+      in HTML).
     format: uri
     minLength: 1
     rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2314,8 +2260,8 @@ properties:
     type: string
   themes:
     default:
-    description: A knowledge organization system (KOS) used to classify the 
-      resources documented in the catalog (e.g., datasets and services).
+    description: A knowledge organization system (KOS) used to classify the resources
+      documented in the catalog (e.g., datasets and services).
     items:
       format: uri
       minLength: 1

--- a/models/health_dcat/HEALTHDCATAPDataService.yaml
+++ b/models/health_dcat/HEALTHDCATAPDataService.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -354,15 +344,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -373,8 +361,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -388,9 +376,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -414,8 +401,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -427,14 +414,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -445,8 +431,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -466,9 +452,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -484,17 +469,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -505,8 +488,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -522,17 +505,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -562,15 +543,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -608,15 +588,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -627,8 +606,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -657,8 +636,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -668,8 +647,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -683,8 +662,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -695,8 +674,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -705,8 +684,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -715,8 +694,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -782,8 +761,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -801,8 +780,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -815,8 +794,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -850,14 +829,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -866,8 +844,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -881,9 +859,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -907,8 +884,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -920,14 +897,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -938,8 +914,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -959,9 +935,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -977,17 +952,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -998,8 +971,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1015,17 +988,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1055,15 +1026,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1101,15 +1071,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1120,8 +1089,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1150,8 +1119,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1161,8 +1130,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1176,8 +1145,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1188,8 +1157,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1198,8 +1167,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1208,8 +1177,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1259,11 +1228,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1272,9 +1240,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1283,10 +1251,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1295,9 +1262,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1306,12 +1273,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1319,11 +1285,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1359,8 +1324,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1372,8 +1337,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1381,8 +1346,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1391,27 +1356,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1457,8 +1422,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -1467,8 +1431,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -1490,26 +1453,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -1526,8 +1488,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -1542,25 +1503,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -1570,8 +1530,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -1588,8 +1547,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -1611,7 +1570,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -1622,8 +1581,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -1655,8 +1613,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -1672,8 +1629,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -1727,8 +1683,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -1739,8 +1695,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -1773,8 +1729,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -1785,8 +1741,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -1797,9 +1753,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -1810,8 +1766,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -1890,8 +1846,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -1909,11 +1864,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1922,9 +1876,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1933,10 +1887,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1945,9 +1898,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1956,12 +1909,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1969,11 +1921,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -2009,8 +1960,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -2018,8 +1968,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -2028,8 +1978,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -2046,15 +1995,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -2071,23 +2019,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -2121,8 +2069,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -2152,14 +2100,13 @@ properties:
   access_rights:
     $ref: '#/$defs/AccessRights'
     default:
-    description: Information about who can access the resource or an indication 
-      of its security status.
+    description: Information about who can access the resource or an indication of
+      its security status.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/conformsTo
@@ -2168,8 +2115,8 @@ properties:
     type: string
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - format: uri
@@ -2183,8 +2130,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -2208,8 +2155,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -2221,14 +2168,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -2239,8 +2185,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -2260,9 +2206,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -2284,10 +2229,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -2298,8 +2242,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -2315,10 +2258,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -2360,8 +2302,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -2399,15 +2340,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -2418,8 +2357,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -2448,8 +2387,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -2459,8 +2398,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -2474,8 +2413,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -2486,8 +2425,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -2496,8 +2435,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -2506,8 +2445,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -2540,8 +2479,8 @@ properties:
     type: array
   endpoint_description:
     default:
-    description: A description of the services available via the end-points, 
-      including their operations, parameters etc.
+    description: A description of the services available via the end-points, including
+      their operations, parameters etc.
     items:
       anyOf:
       - format: uri
@@ -2553,8 +2492,8 @@ properties:
     title: Endpoint Description
     type: array
   endpoint_url:
-    description: The root location or primary endpoint of the service (a 
-      Web-resolvable IRI).
+    description: The root location or primary endpoint of the service (a Web-resolvable
+      IRI).
     items:
       anyOf:
       - format: uri

--- a/models/health_dcat/HEALTHDCATAPDataset.json
+++ b/models/health_dcat/HEALTHDCATAPDataset.json
@@ -2675,7 +2675,7 @@
           ],
           "default": null,
           "description": "Minimum time period resolvable in the dataset.",
-          "rdf_term": "http://www.w3.org/ns/dcat#spatialResolutionInMeters",
+          "rdf_term": "http://www.w3.org/ns/dcat#temporalResolution",
           "rdf_type": "xsd:duration",
           "title": "Temporal Resolution"
         },

--- a/models/health_dcat/HEALTHDCATAPDataset.yaml
+++ b/models/health_dcat/HEALTHDCATAPDataset.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -346,10 +336,10 @@ $defs:
     $ontology: http://spdx.org/rdf/terms/2.3
     $prefix: spdx
     additionalProperties: false
-    description: "A Checksum is value that allows the contents of a file to be authenticated.\
-      \ \nEven small changes to the content of the file will change its checksum.\
-      \ \nThis class allows the results of a variety of checksum and cryptographic
-      message digest algorithms to be \nrepresented."
+    description: "A Checksum is value that allows the contents of a file to be authenticated.
+      \nEven small changes to the content of the file will change its checksum. \n
+      This class allows the results of a variety of checksum and cryptographic message
+      digest algorithms to be \nrepresented."
     properties:
       algorithm:
         description: The algorithm used to produce the subject Checksum.
@@ -363,8 +353,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A lower case hexadecimal encoded digest value produced 
-          using a specific algorithm.
+        description: A lower case hexadecimal encoded digest value produced using
+          a specific algorithm.
         rdf_term: http://spdx.org/rdf/terms#checksumValue
         rdf_type: xsd:hexBinary
         title: Checksum Value
@@ -379,20 +369,19 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -401,8 +390,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -416,9 +405,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -442,8 +430,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -455,14 +443,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -473,8 +460,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -494,9 +481,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -512,17 +498,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -533,8 +517,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -550,17 +534,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -590,15 +572,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -636,15 +617,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -655,8 +635,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -685,8 +665,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -696,8 +676,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -711,8 +691,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -723,8 +703,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -733,8 +713,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -743,8 +723,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -777,8 +757,8 @@ $defs:
         type: array
       endpoint_description:
         default:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         items:
           anyOf:
           - format: uri
@@ -790,8 +770,8 @@ $defs:
         title: Endpoint Description
         type: array
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         items:
           anyOf:
           - format: uri
@@ -835,15 +815,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -854,8 +832,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -869,9 +847,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -895,8 +872,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -908,14 +885,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -926,8 +902,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -947,9 +923,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -965,17 +940,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -986,8 +959,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1003,17 +976,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1043,15 +1014,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1089,15 +1059,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1108,8 +1077,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1138,8 +1107,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1149,8 +1118,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1164,8 +1133,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1176,8 +1145,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1186,8 +1155,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1196,8 +1165,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1263,8 +1232,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -1282,8 +1251,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -1296,8 +1265,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -1331,14 +1300,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -1347,8 +1315,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -1362,9 +1330,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -1388,8 +1355,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -1401,14 +1368,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -1419,8 +1385,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -1440,9 +1406,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -1458,17 +1423,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1479,8 +1442,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1496,17 +1459,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1536,15 +1497,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1582,15 +1542,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1601,8 +1560,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1631,8 +1590,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1642,8 +1601,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1657,8 +1616,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1669,8 +1628,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1679,8 +1638,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1689,8 +1648,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1740,11 +1699,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1753,9 +1711,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1764,10 +1722,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1776,9 +1733,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1787,12 +1744,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1800,11 +1756,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1840,8 +1795,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1853,8 +1808,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1862,8 +1817,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1872,27 +1827,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1938,8 +1893,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -1948,8 +1902,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -1971,26 +1924,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -2007,8 +1959,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -2023,25 +1974,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -2051,8 +2001,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -2087,8 +2036,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -2099,8 +2048,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2153,8 +2102,7 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          distribution.
+        description: Date of formal issuance (e.g., publication) of the distribution.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
@@ -2166,15 +2114,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the distribution was changed, 
-          updated or modified.
+        description: Most recent date on which the distribution was changed, updated
+          or modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       license:
         default:
-        description: A legal document under which the distribution is made 
-          available.
+        description: A legal document under which the distribution is made available.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/license
@@ -2183,8 +2130,7 @@ $defs:
         type: string
       access_rights:
         default:
-        description: A rights statement that concerns how the distribution is 
-          accessed.
+        description: A rights statement that concerns how the distribution is accessed.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -2205,13 +2151,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the distribution.
+        description: An ODRL conformant policy expressing the rights associated with
+          the distribution.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       access_url:
-        description: A URL of the resource that gives access to a distribution 
-          of the dataset. E.g., landing page, feed, SPARQL endpoint.
+        description: A URL of the resource that gives access to a distribution of
+          the dataset. E.g., landing page, feed, SPARQL endpoint.
         items:
           format: uri
           minLength: 1
@@ -2222,8 +2168,7 @@ $defs:
         type: array
       access_service:
         default:
-        description: A data service that gives access to the distribution of the
-          dataset
+        description: A data service that gives access to the distribution of the dataset
         items:
           anyOf:
           - format: uri
@@ -2236,9 +2181,9 @@ $defs:
         type: array
       download_url:
         default:
-        description: The URL of the downloadable file in a given format. E.g., 
-          CSV file or RDF file. The format is indicated by the distribution's 
-          dcterms:format and/or dcat:mediaType
+        description: The URL of the downloadable file in a given format. E.g., CSV
+          file or RDF file. The format is indicated by the distribution's dcterms:format
+          and/or dcat:mediaType
         items:
           format: uri
           minLength: 1
@@ -2261,8 +2206,8 @@ $defs:
         - type: number
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Minimum spatial separation resolvable in a dataset 
-          distribution, measured in meters.
+        description: Minimum spatial separation resolvable in a dataset distribution,
+          measured in meters.
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
         rdf_type: xsd:decimal
         title: Spatial Resolution
@@ -2272,7 +2217,7 @@ $defs:
         - $ref: '#/$defs/LiteralField'
         default:
         description: Minimum time period resolvable in the dataset.
-        rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
+        rdf_term: http://www.w3.org/ns/dcat#temporalResolution
         rdf_type: xsd:duration
         title: Temporal Resolution
       conforms_to:
@@ -2306,9 +2251,9 @@ $defs:
         type: string
       compression_format:
         default:
-        description: The compression format of the distribution in which the 
-          data is contained in a compressed form, e.g., to reduce the size of 
-          the downloadable file.
+        description: The compression format of the distribution in which the data
+          is contained in a compressed form, e.g., to reduce the size of the downloadable
+          file.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#compressFormat
@@ -2317,9 +2262,9 @@ $defs:
         type: string
       packaging_format:
         default:
-        description: The package format of the distribution in which one or more
-          data files are grouped together, e.g., to enable a set of related 
-          files to be downloaded together.
+        description: The package format of the distribution in which one or more data
+          files are grouped together, e.g., to enable a set of related files to be
+          downloaded together.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#packageFormat
@@ -2329,9 +2274,8 @@ $defs:
       checksum:
         $ref: '#/$defs/Checksum'
         default:
-        description: The checksum property provides a mechanism that can be used
-          to verify that the contents of a file or package have not changed 
-          [SPDX].
+        description: The checksum property provides a mechanism that can be used to
+          verify that the contents of a file or package have not changed [SPDX].
         rdf_term: http://spdx.org/rdf/terms#checksum
         rdf_type: uri
       retention_period:
@@ -2341,8 +2285,8 @@ $defs:
           type: string
         - $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: uri
         title: Retention Period
@@ -2371,8 +2315,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Health Data Access Body supporting access to data in the Member
-      State.
+    description: Health Data Access Body supporting access to data in the Member State.
     properties:
       name:
         description: A name of the agent
@@ -2394,8 +2337,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -2406,8 +2349,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2456,8 +2399,8 @@ $defs:
         type: string
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -2477,8 +2420,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact or provides 
-          information on how to get in touch.
+        description: A webpage that either allows to make contact or provides information
+          on how to get in touch.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasURL
@@ -2495,8 +2438,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Agent responsible for making the health data resource 
-      available.
+    description: Agent responsible for making the health data resource available.
     properties:
       name:
         description: A name of the agent
@@ -2518,8 +2460,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -2530,8 +2472,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2580,8 +2522,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -2603,7 +2545,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -2614,8 +2556,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -2647,8 +2588,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -2664,8 +2604,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -2719,8 +2658,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -2731,8 +2670,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -2765,8 +2704,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -2777,8 +2716,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -2789,9 +2728,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -2802,8 +2741,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -2882,8 +2821,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -2901,11 +2839,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -2914,9 +2851,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -2925,10 +2862,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -2937,9 +2873,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -2948,12 +2884,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -2961,11 +2896,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -3001,8 +2935,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -3010,8 +2943,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -3020,8 +2953,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -3038,15 +2970,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -3063,23 +2994,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -3113,8 +3044,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -3142,8 +3073,7 @@ $prefix: dcat
 additionalProperties: false
 properties:
   access_rights:
-    description: Information about who can access the dataset and under what 
-      conditions.
+    description: Information about who can access the dataset and under what conditions.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/accessRights
@@ -3152,8 +3082,7 @@ properties:
     type: string
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     items:
       format: uri
       minLength: 1
@@ -3163,8 +3092,8 @@ properties:
     title: Conforms To
     type: array
   contact_point:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - $ref: '#/$defs/HEALTHDCATAPKind'
@@ -3177,8 +3106,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - $ref: '#/$defs/HEALTHDCATAPAgent'
@@ -3201,8 +3130,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -3214,13 +3143,12 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -3231,8 +3159,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -3252,9 +3180,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -3276,10 +3203,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -3290,8 +3216,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -3307,10 +3232,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -3327,8 +3251,7 @@ properties:
     type: array
   publisher:
     default:
-    description: Agent responsible for making the health data resource 
-      available.
+    description: Agent responsible for making the health data resource available.
     items:
       anyOf:
       - format: uri
@@ -3353,8 +3276,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -3392,15 +3314,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -3411,8 +3331,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -3441,8 +3361,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -3452,8 +3372,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -3467,8 +3387,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -3479,8 +3399,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -3489,8 +3409,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -3499,8 +3419,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -3565,8 +3485,7 @@ properties:
     type: array
   spatial_resolution:
     default:
-    description: Minimum spatial separation resolvable in a dataset, measured in
-      meters.
+    description: Minimum spatial separation resolvable in a dataset, measured in meters.
     items:
       type: number
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -3584,8 +3503,8 @@ properties:
     title: Temporal Resolution
   was_generated_by:
     default:
-    description: An activity that generated, or provides the business context 
-      for, the creation of the dataset.
+    description: An activity that generated, or provides the business context for,
+      the creation of the dataset.
     items:
       anyOf:
       - format: uri
@@ -3597,8 +3516,7 @@ properties:
     title: Was Generated By
     type: array
   applicable_legislation:
-    description: The legislation that mandates the creation or management of the
-      dataset.
+    description: The legislation that mandates the creation or management of the dataset.
     items:
       format: uri
       minLength: 1
@@ -3642,8 +3560,7 @@ properties:
     type: array
   coding_system:
     default:
-    description: Health classifications and their codes associated with the 
-      dataset
+    description: Health classifications and their codes associated with the dataset
     items:
       format: uri
       minLength: 1
@@ -3680,8 +3597,7 @@ properties:
       type: string
     - $ref: '#/$defs/HEALTHDCATAPHdab'
     default:
-    description: Health Data Access Body supporting access to data in the Member
-      State.
+    description: Health Data Access Body supporting access to data in the Member State.
     rdf_term: http://healthdataportal.eu/ns/health#hdab
     rdf_type: uri
     title: Hdab
@@ -3746,8 +3662,7 @@ properties:
   retention_period:
     $ref: '#/$defs/PeriodOfTime'
     default:
-    description: A temporal period which the dataset is available for secondary 
-      use.
+    description: A temporal period which the dataset is available for secondary use.
     rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
     rdf_type: http://purl.org/dc/terms/PeriodOfTime
 required:

--- a/models/health_dcat/HEALTHDCATAPDatasetSeries.yaml
+++ b/models/health_dcat/HEALTHDCATAPDatasetSeries.yaml
@@ -34,8 +34,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -46,8 +46,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -65,8 +65,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -78,8 +78,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -87,8 +87,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -97,27 +97,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -163,8 +163,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -173,8 +172,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -196,26 +194,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -232,8 +229,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -248,25 +244,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -276,8 +271,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -288,7 +282,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -299,8 +293,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -332,8 +325,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -349,8 +341,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -404,8 +395,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -416,8 +407,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -450,8 +441,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -462,8 +453,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -474,9 +465,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -487,8 +478,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -567,8 +558,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -599,8 +589,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -608,8 +597,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -618,8 +607,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -636,15 +624,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -661,23 +648,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -711,8 +698,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -742,14 +729,13 @@ properties:
   access_rights:
     $ref: '#/$defs/AccessRights'
     default:
-    description: Information about who can access the resource or an indication 
-      of its security status.
+    description: Information about who can access the resource or an indication of
+      its security status.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/conformsTo
@@ -758,8 +744,8 @@ properties:
     type: string
   contact_point:
     default:
-    description: Relevant contact information for the cataloged resource. Use of
-      vCard is recommended
+    description: Relevant contact information for the cataloged resource. Use of vCard
+      is recommended
     items:
       anyOf:
       - format: uri
@@ -773,8 +759,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -798,8 +784,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -811,14 +797,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -829,8 +814,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -850,9 +835,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -874,10 +858,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -888,8 +871,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -905,10 +887,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -950,8 +931,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -989,15 +969,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -1008,8 +986,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1038,8 +1016,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -1049,8 +1027,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -1064,8 +1042,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -1076,8 +1054,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -1086,8 +1064,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -1096,8 +1074,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1

--- a/models/health_dcat/HEALTHDCATAPDistribution.json
+++ b/models/health_dcat/HEALTHDCATAPDistribution.json
@@ -3231,7 +3231,7 @@
       ],
       "default": null,
       "description": "Minimum time period resolvable in the dataset.",
-      "rdf_term": "http://www.w3.org/ns/dcat#spatialResolutionInMeters",
+      "rdf_term": "http://www.w3.org/ns/dcat#temporalResolution",
       "rdf_type": "xsd:duration",
       "title": "Temporal Resolution"
     },

--- a/models/health_dcat/HEALTHDCATAPDistribution.yaml
+++ b/models/health_dcat/HEALTHDCATAPDistribution.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -346,10 +336,10 @@ $defs:
     $ontology: http://spdx.org/rdf/terms/2.3
     $prefix: spdx
     additionalProperties: false
-    description: "A Checksum is value that allows the contents of a file to be authenticated.\
-      \ \nEven small changes to the content of the file will change its checksum.\
-      \ \nThis class allows the results of a variety of checksum and cryptographic
-      message digest algorithms to be \nrepresented."
+    description: "A Checksum is value that allows the contents of a file to be authenticated.
+      \nEven small changes to the content of the file will change its checksum. \n
+      This class allows the results of a variety of checksum and cryptographic message
+      digest algorithms to be \nrepresented."
     properties:
       algorithm:
         description: The algorithm used to produce the subject Checksum.
@@ -363,8 +353,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A lower case hexadecimal encoded digest value produced 
-          using a specific algorithm.
+        description: A lower case hexadecimal encoded digest value produced using
+          a specific algorithm.
         rdf_term: http://spdx.org/rdf/terms#checksumValue
         rdf_type: xsd:hexBinary
         title: Checksum Value
@@ -379,20 +369,19 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -401,8 +390,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -416,9 +405,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -442,8 +430,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -455,14 +443,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -473,8 +460,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -494,9 +481,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -512,17 +498,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -533,8 +517,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -550,17 +534,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -590,15 +572,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -636,15 +617,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -655,8 +635,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -685,8 +665,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -696,8 +676,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -711,8 +691,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -723,8 +703,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -733,8 +713,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -743,8 +723,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -777,8 +757,8 @@ $defs:
         type: array
       endpoint_description:
         default:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         items:
           anyOf:
           - format: uri
@@ -790,8 +770,8 @@ $defs:
         title: Endpoint Description
         type: array
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         items:
           anyOf:
           - format: uri
@@ -835,15 +815,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -854,8 +832,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -869,9 +847,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -895,8 +872,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -908,14 +885,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -926,8 +902,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -947,9 +923,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -965,17 +940,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -986,8 +959,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1003,17 +976,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1043,15 +1014,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1089,15 +1059,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1108,8 +1077,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1138,8 +1107,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1149,8 +1118,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1164,8 +1133,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1176,8 +1145,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1186,8 +1155,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1196,8 +1165,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1263,8 +1232,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -1282,8 +1251,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -1296,8 +1265,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -1331,14 +1300,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -1347,8 +1315,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -1362,9 +1330,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -1388,8 +1355,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -1401,14 +1368,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -1419,8 +1385,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -1440,9 +1406,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -1458,17 +1423,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1479,8 +1442,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1496,17 +1459,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1536,15 +1497,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1582,15 +1542,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1601,8 +1560,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1631,8 +1590,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1642,8 +1601,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1657,8 +1616,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1669,8 +1628,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1679,8 +1638,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1689,8 +1648,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1740,11 +1699,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1753,9 +1711,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1764,10 +1722,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1776,9 +1733,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1787,12 +1744,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1800,11 +1756,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1840,8 +1795,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1853,8 +1808,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1862,8 +1817,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1872,27 +1827,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1938,8 +1893,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -1948,8 +1902,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -1971,26 +1924,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -2007,8 +1959,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -2023,25 +1974,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -2051,8 +2001,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -2069,8 +2018,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -2092,7 +2041,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -2103,8 +2052,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -2136,8 +2084,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -2153,8 +2100,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -2208,8 +2154,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -2220,8 +2166,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -2254,8 +2200,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -2266,8 +2212,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -2278,9 +2224,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -2291,8 +2237,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -2371,8 +2317,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -2390,11 +2335,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -2403,9 +2347,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -2414,10 +2358,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -2426,9 +2369,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -2437,12 +2380,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -2450,11 +2392,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -2490,8 +2431,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -2499,8 +2439,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -2509,8 +2449,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -2527,15 +2466,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -2552,23 +2490,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -2602,8 +2540,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -2653,8 +2591,7 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Date of formal issuance (e.g., publication) of the 
-      distribution.
+    description: Date of formal issuance (e.g., publication) of the distribution.
     rdf_term: http://purl.org/dc/terms/issued
     rdf_type: datetime_literal
     title: Release Date
@@ -2666,15 +2603,14 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the distribution was changed, updated
-      or modified.
+    description: Most recent date on which the distribution was changed, updated or
+      modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   license:
     default:
-    description: A legal document under which the distribution is made 
-      available.
+    description: A legal document under which the distribution is made available.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/license
@@ -2683,8 +2619,7 @@ properties:
     type: string
   access_rights:
     default:
-    description: A rights statement that concerns how the distribution is 
-      accessed.
+    description: A rights statement that concerns how the distribution is accessed.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/accessRights
@@ -2705,13 +2640,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the distribution.
+    description: An ODRL conformant policy expressing the rights associated with the
+      distribution.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   access_url:
-    description: A URL of the resource that gives access to a distribution of 
-      the dataset. E.g., landing page, feed, SPARQL endpoint.
+    description: A URL of the resource that gives access to a distribution of the
+      dataset. E.g., landing page, feed, SPARQL endpoint.
     items:
       format: uri
       minLength: 1
@@ -2722,8 +2657,7 @@ properties:
     type: array
   access_service:
     default:
-    description: A data service that gives access to the distribution of the 
-      dataset
+    description: A data service that gives access to the distribution of the dataset
     items:
       anyOf:
       - format: uri
@@ -2736,9 +2670,9 @@ properties:
     type: array
   download_url:
     default:
-    description: The URL of the downloadable file in a given format. E.g., CSV 
-      file or RDF file. The format is indicated by the distribution's 
-      dcterms:format and/or dcat:mediaType
+    description: The URL of the downloadable file in a given format. E.g., CSV file
+      or RDF file. The format is indicated by the distribution's dcterms:format and/or
+      dcat:mediaType
     items:
       format: uri
       minLength: 1
@@ -2761,8 +2695,8 @@ properties:
     - type: number
     - $ref: '#/$defs/LiteralField'
     default:
-    description: Minimum spatial separation resolvable in a dataset 
-      distribution, measured in meters.
+    description: Minimum spatial separation resolvable in a dataset distribution,
+      measured in meters.
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
     rdf_type: xsd:decimal
     title: Spatial Resolution
@@ -2772,7 +2706,7 @@ properties:
     - $ref: '#/$defs/LiteralField'
     default:
     description: Minimum time period resolvable in the dataset.
-    rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
+    rdf_term: http://www.w3.org/ns/dcat#temporalResolution
     rdf_type: xsd:duration
     title: Temporal Resolution
   conforms_to:
@@ -2806,9 +2740,8 @@ properties:
     type: string
   compression_format:
     default:
-    description: The compression format of the distribution in which the data is
-      contained in a compressed form, e.g., to reduce the size of the 
-      downloadable file.
+    description: The compression format of the distribution in which the data is contained
+      in a compressed form, e.g., to reduce the size of the downloadable file.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#compressFormat
@@ -2817,9 +2750,9 @@ properties:
     type: string
   packaging_format:
     default:
-    description: The package format of the distribution in which one or more 
-      data files are grouped together, e.g., to enable a set of related files to
-      be downloaded together.
+    description: The package format of the distribution in which one or more data
+      files are grouped together, e.g., to enable a set of related files to be downloaded
+      together.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#packageFormat
@@ -2829,8 +2762,8 @@ properties:
   checksum:
     $ref: '#/$defs/Checksum'
     default:
-    description: The checksum property provides a mechanism that can be used to 
-      verify that the contents of a file or package have not changed [SPDX].
+    description: The checksum property provides a mechanism that can be used to verify
+      that the contents of a file or package have not changed [SPDX].
     rdf_term: http://spdx.org/rdf/terms#checksum
     rdf_type: uri
   retention_period:
@@ -2840,8 +2773,7 @@ properties:
       type: string
     - $ref: '#/$defs/PeriodOfTime'
     default:
-    description: A temporal period which the dataset is available for secondary 
-      use.
+    description: A temporal period which the dataset is available for secondary use.
     rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
     rdf_type: uri
     title: Retention Period

--- a/models/health_dcat/HEALTHDCATAPHdab.yaml
+++ b/models/health_dcat/HEALTHDCATAPHdab.yaml
@@ -22,8 +22,8 @@ $defs:
         type: string
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -43,8 +43,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact or provides 
-          information on how to get in touch.
+        description: A webpage that either allows to make contact or provides information
+          on how to get in touch.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasURL
@@ -58,7 +58,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -69,8 +69,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -92,8 +91,7 @@ $ontology:
 - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
 $prefix: foaf
 additionalProperties: false
-description: Health Data Access Body supporting access to data in the Member 
-  State.
+description: Health Data Access Body supporting access to data in the Member State.
 properties:
   name:
     description: A name of the agent
@@ -115,8 +113,8 @@ properties:
     title: Identifier
   mbox:
     default:
-    description: A personal mailbox, ie. an Internet mailbox associated with 
-      exactly one owner, the first owner of this mailbox.
+    description: A personal mailbox, ie. an Internet mailbox associated with exactly
+      one owner, the first owner of this mailbox.
     items:
       format: uri
       minLength: 1
@@ -127,8 +125,8 @@ properties:
     type: array
   homepage:
     default:
-    description: A webpage that either allows to make contact (i.e. a webform) 
-      or the information contains how to get into contact.
+    description: A webpage that either allows to make contact (i.e. a webform) or
+      the information contains how to get into contact.
     format: uri
     minLength: 1
     rdf_term: http://xmlns.com/foaf/0.1/homepage

--- a/models/health_dcat/HEALTHDCATAPKind.yaml
+++ b/models/health_dcat/HEALTHDCATAPKind.yaml
@@ -5,7 +5,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -16,8 +16,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -53,8 +52,8 @@ properties:
     type: string
   formatted_name:
     default:
-    description: The full name of the object (as a single string). This is the 
-      only mandatory property.
+    description: The full name of the object (as a single string). This is the only
+      mandatory property.
     items:
       anyOf:
       - type: string
@@ -74,8 +73,8 @@ properties:
     type: string
   contact_page:
     default:
-    description: A webpage that either allows to make contact or provides 
-      information on how to get in touch.
+    description: A webpage that either allows to make contact or provides information
+      on how to get in touch.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/2006/vcard/ns#hasURL

--- a/models/health_dcat/HEALTHDCATAPPublisher.yaml
+++ b/models/health_dcat/HEALTHDCATAPPublisher.yaml
@@ -22,8 +22,8 @@ $defs:
         type: string
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -43,8 +43,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact or provides 
-          information on how to get in touch.
+        description: A webpage that either allows to make contact or provides information
+          on how to get in touch.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasURL
@@ -58,7 +58,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -69,8 +69,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -114,8 +113,8 @@ properties:
     title: Identifier
   mbox:
     default:
-    description: A personal mailbox, ie. an Internet mailbox associated with 
-      exactly one owner, the first owner of this mailbox.
+    description: A personal mailbox, ie. an Internet mailbox associated with exactly
+      one owner, the first owner of this mailbox.
     items:
       format: uri
       minLength: 1
@@ -126,8 +125,8 @@ properties:
     type: array
   homepage:
     default:
-    description: A webpage that either allows to make contact (i.e. a webform) 
-      or the information contains how to get into contact.
+    description: A webpage that either allows to make contact (i.e. a webform) or
+      the information contains how to get into contact.
     format: uri
     minLength: 1
     rdf_term: http://xmlns.com/foaf/0.1/homepage

--- a/models/hri_dcat/HRIAgent.yaml
+++ b/models/hri_dcat/HRIAgent.yaml
@@ -10,26 +10,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -46,8 +45,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -62,25 +60,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -90,8 +87,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -102,7 +98,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -113,8 +109,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -146,8 +141,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -163,8 +157,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -187,8 +180,7 @@ properties:
     title: Name
     type: array
   identifier:
-    description: An unambiguous reference to the resource within a given 
-      context.
+    description: An unambiguous reference to the resource within a given context.
     items:
       anyOf:
       - type: string

--- a/models/hri_dcat/HRICatalog.json
+++ b/models/hri_dcat/HRICatalog.json
@@ -4864,7 +4864,7 @@
           ],
           "default": null,
           "description": "Minimum time period resolvable in the dataset.",
-          "rdf_term": "http://www.w3.org/ns/dcat#spatialResolutionInMeters",
+          "rdf_term": "http://www.w3.org/ns/dcat#temporalResolution",
           "rdf_type": "xsd:duration",
           "title": "Temporal Resolution"
         },

--- a/models/hri_dcat/HRICatalog.yaml
+++ b/models/hri_dcat/HRICatalog.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -354,15 +344,15 @@ $defs:
           type: string
         - $ref: '#/$defs/Agent'
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource.
         rdf_term: http://www.w3.org/ns/prov#agent
         rdf_type: uri
         title: Agent
       role:
         default:
-        description: The function of an entity or agent with respect to another 
-          entity or resource.
+        description: The function of an entity or agent with respect to another entity
+          or resource.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hadRole
@@ -377,10 +367,10 @@ $defs:
     $ontology: http://spdx.org/rdf/terms/2.3
     $prefix: spdx
     additionalProperties: false
-    description: "A Checksum is value that allows the contents of a file to be authenticated.\
-      \ \nEven small changes to the content of the file will change its checksum.\
-      \ \nThis class allows the results of a variety of checksum and cryptographic
-      message digest algorithms to be \nrepresented."
+    description: "A Checksum is value that allows the contents of a file to be authenticated.
+      \nEven small changes to the content of the file will change its checksum. \n
+      This class allows the results of a variety of checksum and cryptographic message
+      digest algorithms to be \nrepresented."
     properties:
       algorithm:
         description: The algorithm used to produce the subject Checksum.
@@ -394,8 +384,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A lower case hexadecimal encoded digest value produced 
-          using a specific algorithm.
+        description: A lower case hexadecimal encoded digest value produced using
+          a specific algorithm.
         rdf_term: http://spdx.org/rdf/terms#checksumValue
         rdf_type: xsd:hexBinary
         title: Checksum Value
@@ -444,20 +434,19 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -466,8 +455,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -481,9 +470,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -507,8 +495,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -520,14 +508,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -538,8 +525,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -559,9 +546,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -577,17 +563,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -598,8 +582,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -615,17 +599,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -655,15 +637,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -701,15 +682,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -720,8 +700,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -750,8 +730,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -761,8 +741,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -776,8 +756,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -788,8 +768,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -798,8 +778,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -808,8 +788,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -842,8 +822,8 @@ $defs:
         type: array
       endpoint_description:
         default:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         items:
           anyOf:
           - format: uri
@@ -855,8 +835,8 @@ $defs:
         title: Endpoint Description
         type: array
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         items:
           anyOf:
           - format: uri
@@ -900,15 +880,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -919,8 +897,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -934,9 +912,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -960,8 +937,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -973,14 +950,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -991,8 +967,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -1012,9 +988,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -1030,17 +1005,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1051,8 +1024,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1068,17 +1041,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1108,15 +1079,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1154,15 +1124,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1173,8 +1142,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1203,8 +1172,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1214,8 +1183,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1229,8 +1198,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1241,8 +1210,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1251,8 +1220,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1261,8 +1230,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1328,8 +1297,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -1347,8 +1316,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -1361,8 +1330,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -1396,14 +1365,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -1412,8 +1380,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -1427,9 +1395,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -1453,8 +1420,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -1466,14 +1433,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -1484,8 +1450,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -1505,9 +1471,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -1523,17 +1488,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1544,8 +1507,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1561,17 +1524,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1601,15 +1562,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1647,15 +1607,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1666,8 +1625,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1696,8 +1655,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1707,8 +1666,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1722,8 +1681,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1734,8 +1693,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1744,8 +1703,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1754,8 +1713,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1833,11 +1792,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1846,9 +1804,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1857,10 +1815,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1869,9 +1826,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1880,12 +1837,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1893,11 +1849,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1933,8 +1888,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1946,8 +1901,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1955,8 +1910,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1965,27 +1920,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -2031,8 +1986,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -2041,8 +1995,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -2064,26 +2017,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -2100,8 +2052,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -2116,25 +2067,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -2144,8 +2094,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -2211,8 +2160,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -2223,8 +2172,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2261,15 +2210,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -2280,8 +2227,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -2295,9 +2242,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -2321,8 +2267,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -2334,14 +2280,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -2352,8 +2297,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -2373,9 +2318,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -2391,17 +2335,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -2412,8 +2354,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -2429,17 +2371,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -2469,15 +2409,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -2515,15 +2454,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -2534,8 +2472,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -2564,8 +2502,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -2575,8 +2513,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -2590,8 +2528,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -2602,8 +2540,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -2612,8 +2550,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -2622,8 +2560,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -2689,8 +2627,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -2708,8 +2646,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -2722,8 +2660,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -2743,8 +2681,8 @@ $defs:
         type: array
       catalog_record:
         default:
-        description: A record describing the registration of a single resource 
-          (e.g., a dataset, a data service) that is part of the catalog.
+        description: A record describing the registration of a single resource (e.g.,
+          a dataset, a data service) that is part of the catalog.
         items:
           anyOf:
           - format: uri
@@ -2792,8 +2730,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A homepage of the catalog (a public Web document usually 
-          available in HTML).
+        description: A homepage of the catalog (a public Web document usually available
+          in HTML).
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2802,8 +2740,8 @@ $defs:
         type: string
       themes:
         default:
-        description: A knowledge organization system (KOS) used to classify the 
-          resources documented in the catalog (e.g., datasets and services).
+        description: A knowledge organization system (KOS) used to classify the resources
+          documented in the catalog (e.g., datasets and services).
         items:
           format: uri
           minLength: 1
@@ -2827,8 +2765,7 @@ $defs:
     additionalProperties: false
     properties:
       access_rights:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -2837,8 +2774,7 @@ $defs:
         type: string
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -2848,8 +2784,8 @@ $defs:
         title: Conforms To
         type: array
       contact_point:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - $ref: '#/$defs/HEALTHDCATAPKind'
@@ -2862,9 +2798,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - $ref: '#/$defs/HEALTHDCATAPAgent'
@@ -2887,8 +2822,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -2900,13 +2835,12 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -2917,8 +2851,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -2938,9 +2872,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -2956,17 +2889,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -2977,8 +2908,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -2994,17 +2925,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -3015,8 +2944,7 @@ $defs:
         type: array
       publisher:
         default:
-        description: Agent responsible for making the health data resource 
-          available.
+        description: Agent responsible for making the health data resource available.
         items:
           anyOf:
           - format: uri
@@ -3035,15 +2963,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -3081,15 +3008,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -3100,8 +3026,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -3130,8 +3056,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -3141,8 +3067,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -3156,8 +3082,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -3168,8 +3094,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -3178,8 +3104,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -3188,8 +3114,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -3254,8 +3180,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -3273,8 +3199,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -3286,8 +3212,8 @@ $defs:
         title: Was Generated By
         type: array
       applicable_legislation:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -3331,8 +3257,7 @@ $defs:
         type: array
       coding_system:
         default:
-        description: Health classifications and their codes associated with the 
-          dataset
+        description: Health classifications and their codes associated with the dataset
         items:
           format: uri
           minLength: 1
@@ -3369,15 +3294,14 @@ $defs:
           type: string
         - $ref: '#/$defs/HEALTHDCATAPHdab'
         default:
-        description: Health Data Access Body supporting access to data in the 
-          Member State.
+        description: Health Data Access Body supporting access to data in the Member
+          State.
         rdf_term: http://healthdataportal.eu/ns/health#hdab
         rdf_type: uri
         title: Hdab
       legal_basis:
         default:
-        description: The legal basis used to justify processing of personal 
-          data.
+        description: The legal basis used to justify processing of personal data.
         items:
           format: uri
           minLength: 1
@@ -3436,8 +3360,8 @@ $defs:
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: http://purl.org/dc/terms/PeriodOfTime
     required:
@@ -3463,14 +3387,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -3479,8 +3402,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -3494,9 +3417,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -3520,8 +3442,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -3533,14 +3455,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -3551,8 +3472,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -3572,9 +3493,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -3590,17 +3510,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -3611,8 +3529,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -3628,17 +3546,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -3668,15 +3584,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -3714,15 +3629,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -3733,8 +3647,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -3763,8 +3677,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -3774,8 +3688,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -3789,8 +3703,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -3801,8 +3715,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -3811,8 +3725,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -3821,8 +3735,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -3890,8 +3804,7 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          distribution.
+        description: Date of formal issuance (e.g., publication) of the distribution.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
@@ -3903,15 +3816,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the distribution was changed, 
-          updated or modified.
+        description: Most recent date on which the distribution was changed, updated
+          or modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       license:
         default:
-        description: A legal document under which the distribution is made 
-          available.
+        description: A legal document under which the distribution is made available.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/license
@@ -3920,8 +3832,7 @@ $defs:
         type: string
       access_rights:
         default:
-        description: A rights statement that concerns how the distribution is 
-          accessed.
+        description: A rights statement that concerns how the distribution is accessed.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -3942,13 +3853,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the distribution.
+        description: An ODRL conformant policy expressing the rights associated with
+          the distribution.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       access_url:
-        description: A URL of the resource that gives access to a distribution 
-          of the dataset. E.g., landing page, feed, SPARQL endpoint.
+        description: A URL of the resource that gives access to a distribution of
+          the dataset. E.g., landing page, feed, SPARQL endpoint.
         items:
           format: uri
           minLength: 1
@@ -3959,8 +3870,7 @@ $defs:
         type: array
       access_service:
         default:
-        description: A data service that gives access to the distribution of the
-          dataset
+        description: A data service that gives access to the distribution of the dataset
         items:
           anyOf:
           - format: uri
@@ -3973,9 +3883,9 @@ $defs:
         type: array
       download_url:
         default:
-        description: The URL of the downloadable file in a given format. E.g., 
-          CSV file or RDF file. The format is indicated by the distribution's 
-          dcterms:format and/or dcat:mediaType
+        description: The URL of the downloadable file in a given format. E.g., CSV
+          file or RDF file. The format is indicated by the distribution's dcterms:format
+          and/or dcat:mediaType
         items:
           format: uri
           minLength: 1
@@ -3998,8 +3908,8 @@ $defs:
         - type: number
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Minimum spatial separation resolvable in a dataset 
-          distribution, measured in meters.
+        description: Minimum spatial separation resolvable in a dataset distribution,
+          measured in meters.
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
         rdf_type: xsd:decimal
         title: Spatial Resolution
@@ -4009,7 +3919,7 @@ $defs:
         - $ref: '#/$defs/LiteralField'
         default:
         description: Minimum time period resolvable in the dataset.
-        rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
+        rdf_term: http://www.w3.org/ns/dcat#temporalResolution
         rdf_type: xsd:duration
         title: Temporal Resolution
       conforms_to:
@@ -4043,9 +3953,9 @@ $defs:
         type: string
       compression_format:
         default:
-        description: The compression format of the distribution in which the 
-          data is contained in a compressed form, e.g., to reduce the size of 
-          the downloadable file.
+        description: The compression format of the distribution in which the data
+          is contained in a compressed form, e.g., to reduce the size of the downloadable
+          file.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#compressFormat
@@ -4054,9 +3964,9 @@ $defs:
         type: string
       packaging_format:
         default:
-        description: The package format of the distribution in which one or more
-          data files are grouped together, e.g., to enable a set of related 
-          files to be downloaded together.
+        description: The package format of the distribution in which one or more data
+          files are grouped together, e.g., to enable a set of related files to be
+          downloaded together.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#packageFormat
@@ -4066,9 +3976,8 @@ $defs:
       checksum:
         $ref: '#/$defs/Checksum'
         default:
-        description: The checksum property provides a mechanism that can be used
-          to verify that the contents of a file or package have not changed 
-          [SPDX].
+        description: The checksum property provides a mechanism that can be used to
+          verify that the contents of a file or package have not changed [SPDX].
         rdf_term: http://spdx.org/rdf/terms#checksum
         rdf_type: uri
       retention_period:
@@ -4078,8 +3987,8 @@ $defs:
           type: string
         - $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: uri
         title: Retention Period
@@ -4108,8 +4017,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Health Data Access Body supporting access to data in the Member
-      State.
+    description: Health Data Access Body supporting access to data in the Member State.
     properties:
       name:
         description: A name of the agent
@@ -4131,8 +4039,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -4143,8 +4051,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -4193,8 +4101,8 @@ $defs:
         type: string
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -4214,8 +4122,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact or provides 
-          information on how to get in touch.
+        description: A webpage that either allows to make contact or provides information
+          on how to get in touch.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasURL
@@ -4232,8 +4140,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Agent responsible for making the health data resource 
-      available.
+    description: Agent responsible for making the health data resource available.
     properties:
       name:
         description: A name of the agent
@@ -4255,8 +4162,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -4267,8 +4174,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -4326,8 +4233,7 @@ $defs:
         title: Name
         type: array
       identifier:
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         items:
           anyOf:
           - type: string
@@ -4408,19 +4314,18 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
-        description: Information about who access the resource or an indication 
-          of its security status.
+        description: Information about who access the resource or an indication of
+          its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -4462,8 +4367,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -4475,23 +4380,22 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         rdf_term: http://purl.org/dc/terms/identifier
         rdf_type: rdfs_literal
         title: Identifier
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -4511,9 +4415,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -4528,17 +4431,16 @@ $defs:
           minLength: 1
           type: string
         - $ref: '#/$defs/GeonovumLicences'
-        description: A legal document giving official permission to do something
-          with the resource.
+        description: A legal document giving official permission to do something with
+          the resource.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -4549,8 +4451,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -4572,8 +4474,7 @@ $defs:
         type: array
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -4600,14 +4501,13 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           $ref: '#/$defs/DatasetTheme'
         rdf_term: http://www.w3.org/ns/dcat#theme
@@ -4643,15 +4543,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -4662,8 +4561,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -4692,8 +4591,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -4703,8 +4602,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -4718,8 +4617,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -4730,8 +4629,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -4740,8 +4639,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -4750,8 +4649,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -4783,8 +4682,8 @@ $defs:
         title: Geographical Coverage
         type: array
       endpoint_description:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#endpointDescription
@@ -4792,8 +4691,8 @@ $defs:
         title: Endpoint Description
         type: string
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#endpointURL
@@ -4826,8 +4725,7 @@ $defs:
         type: array
       application_profile:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -4838,8 +4736,7 @@ $defs:
         type: array
       format:
         default:
-        description: The file format, physical medium, or dimensions of the 
-          resource.
+        description: The file format, physical medium, or dimensions of the resource.
         items:
           format: uri
           minLength: 1
@@ -4850,8 +4747,8 @@ $defs:
         type: array
       hvd_category:
         default:
-        description: A data category defined in the High Value Dataset 
-          Implementing Regulation.
+        description: A data category defined in the High Value Dataset Implementing
+          Regulation.
         items:
           format: uri
           minLength: 1
@@ -4897,14 +4794,13 @@ $defs:
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -4947,8 +4843,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -4960,23 +4856,22 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         rdf_term: http://purl.org/dc/terms/identifier
         rdf_type: rdfs_literal
         title: Identifier
       is_referenced_by:
         default:
-        description: A related resource that references, cites, or otherwise 
-          points to the described resource.
+        description: A related resource that references, cites, or otherwise points
+          to the described resource.
         items:
           format: uri
           minLength: 1
@@ -4995,9 +4890,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -5013,17 +4907,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -5034,8 +4926,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -5051,17 +4943,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource.
+        description: Link to a description of a relationship with another resource.
         items:
           anyOf:
           - format: uri
@@ -5090,14 +4980,13 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           $ref: '#/$defs/DatasetTheme'
         rdf_term: http://www.w3.org/ns/dcat#theme
@@ -5133,8 +5022,8 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
@@ -5153,8 +5042,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -5183,8 +5072,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -5194,8 +5083,8 @@ $defs:
       status:
         $ref: '#/$defs/DatasetStatus'
         default:
-        description: The status of the Asset in the context of a particular 
-          workflow process.
+        description: The status of the Asset in the context of a particular workflow
+          process.
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -5209,8 +5098,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -5221,8 +5110,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -5231,8 +5120,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -5241,8 +5130,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -5310,8 +5199,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -5329,8 +5218,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -5353,9 +5242,9 @@ $defs:
         type: array
       other_identifier:
         default:
-        description: Links a resource to an adms:Identifier class. Examples for 
-          secondary identifiers are MAST/ADS, DataCite, DOI, EZID or W3ID (if 
-          not used for the original identifier).
+        description: Links a resource to an adms:Identifier class. Examples for secondary
+          identifiers are MAST/ADS, DataCite, DOI, EZID or W3ID (if not used for the
+          original identifier).
         items:
           $ref: '#/$defs/Identifier'
         rdf_term: http://www.w3.org/ns/adms#identifier
@@ -5388,8 +5277,7 @@ $defs:
         type: array
       coding_system:
         default:
-        description: Health classifications and their codes associated with the 
-          dataset
+        description: Health classifications and their codes associated with the dataset
         items:
           format: uri
           minLength: 1
@@ -5426,8 +5314,8 @@ $defs:
           type: string
         - $ref: '#/$defs/HEALTHDCATAPHdab'
         default:
-        description: Health Data Access Body supporting access to data in the 
-          Member State.
+        description: Health Data Access Body supporting access to data in the Member
+          State.
         rdf_term: http://healthdataportal.eu/ns/health#hdab
         rdf_type: uri
         title: Hdab
@@ -5492,8 +5380,8 @@ $defs:
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: http://purl.org/dc/terms/PeriodOfTime
       documentation:
@@ -5557,8 +5445,7 @@ $defs:
         type: array
       source:
         default:
-        description: A related resource from which the described resource is 
-          derived.
+        description: A related resource from which the described resource is derived.
         items:
           anyOf:
           - format: uri
@@ -5596,8 +5483,8 @@ $defs:
       Group)"
     properties:
       hasEmail:
-        description: To specify the electronic mail address for communication 
-          with the object.
+        description: To specify the electronic mail address for communication with
+          the object.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasEmail
@@ -5623,8 +5510,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact (e.g. a 
-          webform) or provides information on how to get in touch.
+        description: A webpage that either allows to make contact (e.g. a webform)
+          or provides information on how to get in touch.
         items:
           format: uri
           minLength: 1
@@ -5649,8 +5536,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -5672,7 +5559,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -5683,8 +5570,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -5716,8 +5602,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -5733,8 +5618,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -5788,8 +5672,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -5800,8 +5684,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -5834,8 +5718,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -5846,8 +5730,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -5858,9 +5742,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -5871,8 +5755,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -5967,8 +5851,8 @@ $defs:
         type: string
       body:
         default:
-        description: The object of the relationship is a resource that is a body
-          of the Annotation.
+        description: The object of the relationship is a resource that is a body of
+          the Annotation.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/oa#hasBody
@@ -5979,8 +5863,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -5992,8 +5875,8 @@ $defs:
     additionalProperties: false
     properties:
       had_role:
-        description: The function of an entity or agent with respect to another 
-          entity or resource.
+        description: The function of an entity or agent with respect to another entity
+          or resource.
         items:
           format: uri
           minLength: 1
@@ -6031,11 +5914,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -6044,9 +5926,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -6055,10 +5937,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -6067,9 +5948,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -6078,12 +5959,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -6091,11 +5971,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -6131,8 +6010,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -6140,8 +6018,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -6150,8 +6028,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -6168,15 +6045,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -6193,23 +6069,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -6243,8 +6119,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -6278,15 +6154,13 @@ properties:
       type: string
     - type: 'null'
     default:
-    description: Information about who can access the dataset and under what 
-      conditions.
+    description: Information about who can access the dataset and under what conditions.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
     title: Access Rights
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     items:
       format: uri
       minLength: 1
@@ -6307,8 +6181,8 @@ properties:
     title: Contact Point
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -6331,8 +6205,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       anyOf:
       - format: uri
@@ -6346,14 +6220,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -6364,8 +6237,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -6385,9 +6258,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -6409,10 +6281,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -6423,8 +6294,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -6440,10 +6310,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -6482,8 +6351,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -6521,15 +6389,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -6540,8 +6406,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -6570,8 +6436,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -6581,8 +6447,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -6596,8 +6462,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -6608,8 +6474,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -6618,8 +6484,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -6628,8 +6494,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -6695,8 +6561,7 @@ properties:
     type: array
   spatial_resolution:
     default:
-    description: Minimum spatial separation resolvable in a dataset, measured in
-      meters.
+    description: Minimum spatial separation resolvable in a dataset, measured in meters.
     items:
       type: number
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -6714,8 +6579,8 @@ properties:
     title: Temporal Resolution
   was_generated_by:
     default:
-    description: An activity that generated, or provides the business context 
-      for, the creation of the dataset.
+    description: An activity that generated, or provides the business context for,
+      the creation of the dataset.
     items:
       anyOf:
       - format: uri
@@ -6748,8 +6613,8 @@ properties:
     type: array
   catalog_record:
     default:
-    description: A record describing the registration of a single resource 
-      (e.g., a dataset, a data service) that is part of the catalog.
+    description: A record describing the registration of a single resource (e.g.,
+      a dataset, a data service) that is part of the catalog.
     items:
       anyOf:
       - format: uri
@@ -6798,8 +6663,8 @@ properties:
     type: array
   homepage:
     default:
-    description: A homepage of the catalog (a public Web document usually 
-      available in HTML).
+    description: A homepage of the catalog (a public Web document usually available
+      in HTML).
     format: uri
     minLength: 1
     rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -6808,8 +6673,8 @@ properties:
     type: string
   themes:
     default:
-    description: A knowledge organization system (KOS) used to classify the 
-      resources documented in the catalog (e.g., datasets and services).
+    description: A knowledge organization system (KOS) used to classify the resources
+      documented in the catalog (e.g., datasets and services).
     items:
       format: uri
       minLength: 1

--- a/models/hri_dcat/HRIDataService.json
+++ b/models/hri_dcat/HRIDataService.json
@@ -4096,7 +4096,7 @@
           ],
           "default": null,
           "description": "Minimum time period resolvable in the dataset.",
-          "rdf_term": "http://www.w3.org/ns/dcat#spatialResolutionInMeters",
+          "rdf_term": "http://www.w3.org/ns/dcat#temporalResolution",
           "rdf_type": "xsd:duration",
           "title": "Temporal Resolution"
         },

--- a/models/hri_dcat/HRIDataService.yaml
+++ b/models/hri_dcat/HRIDataService.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -354,15 +344,15 @@ $defs:
           type: string
         - $ref: '#/$defs/Agent'
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource.
         rdf_term: http://www.w3.org/ns/prov#agent
         rdf_type: uri
         title: Agent
       role:
         default:
-        description: The function of an entity or agent with respect to another 
-          entity or resource.
+        description: The function of an entity or agent with respect to another entity
+          or resource.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hadRole
@@ -377,10 +367,10 @@ $defs:
     $ontology: http://spdx.org/rdf/terms/2.3
     $prefix: spdx
     additionalProperties: false
-    description: "A Checksum is value that allows the contents of a file to be authenticated.\
-      \ \nEven small changes to the content of the file will change its checksum.\
-      \ \nThis class allows the results of a variety of checksum and cryptographic
-      message digest algorithms to be \nrepresented."
+    description: "A Checksum is value that allows the contents of a file to be authenticated.
+      \nEven small changes to the content of the file will change its checksum. \n
+      This class allows the results of a variety of checksum and cryptographic message
+      digest algorithms to be \nrepresented."
     properties:
       algorithm:
         description: The algorithm used to produce the subject Checksum.
@@ -394,8 +384,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A lower case hexadecimal encoded digest value produced 
-          using a specific algorithm.
+        description: A lower case hexadecimal encoded digest value produced using
+          a specific algorithm.
         rdf_term: http://spdx.org/rdf/terms#checksumValue
         rdf_type: xsd:hexBinary
         title: Checksum Value
@@ -410,20 +400,19 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -432,8 +421,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -447,9 +436,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -473,8 +461,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -486,14 +474,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -504,8 +491,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -525,9 +512,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -543,17 +529,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -564,8 +548,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -581,17 +565,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -621,15 +603,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -667,15 +648,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -686,8 +666,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -716,8 +696,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -727,8 +707,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -742,8 +722,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -754,8 +734,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -764,8 +744,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -774,8 +754,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -808,8 +788,8 @@ $defs:
         type: array
       endpoint_description:
         default:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         items:
           anyOf:
           - format: uri
@@ -821,8 +801,8 @@ $defs:
         title: Endpoint Description
         type: array
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         items:
           anyOf:
           - format: uri
@@ -866,15 +846,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -885,8 +863,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -900,9 +878,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -926,8 +903,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -939,14 +916,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -957,8 +933,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -978,9 +954,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -996,17 +971,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1017,8 +990,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1034,17 +1007,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1074,15 +1045,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1120,15 +1090,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1139,8 +1108,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1169,8 +1138,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1180,8 +1149,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1195,8 +1164,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1207,8 +1176,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1217,8 +1186,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1227,8 +1196,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1294,8 +1263,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -1313,8 +1282,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -1327,8 +1296,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -1362,14 +1331,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -1378,8 +1346,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -1393,9 +1361,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -1419,8 +1386,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -1432,14 +1399,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -1450,8 +1416,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -1471,9 +1437,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -1489,17 +1454,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1510,8 +1473,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1527,17 +1490,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1567,15 +1528,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1613,15 +1573,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1632,8 +1591,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1662,8 +1621,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1673,8 +1632,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1688,8 +1647,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1700,8 +1659,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1710,8 +1669,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1720,8 +1679,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1799,11 +1758,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1812,9 +1770,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1823,10 +1781,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1835,9 +1792,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1846,12 +1803,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1859,11 +1815,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1899,8 +1854,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1912,8 +1867,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1921,8 +1876,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1931,27 +1886,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1997,8 +1952,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -2007,8 +1961,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -2030,26 +1983,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -2066,8 +2018,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -2082,25 +2033,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -2110,8 +2060,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -2177,8 +2126,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -2189,8 +2138,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2221,8 +2170,7 @@ $defs:
     additionalProperties: false
     properties:
       access_rights:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -2231,8 +2179,7 @@ $defs:
         type: string
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -2242,8 +2189,8 @@ $defs:
         title: Conforms To
         type: array
       contact_point:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - $ref: '#/$defs/HEALTHDCATAPKind'
@@ -2256,9 +2203,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - $ref: '#/$defs/HEALTHDCATAPAgent'
@@ -2281,8 +2227,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -2294,13 +2240,12 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -2311,8 +2256,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -2332,9 +2277,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -2350,17 +2294,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -2371,8 +2313,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -2388,17 +2330,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -2409,8 +2349,7 @@ $defs:
         type: array
       publisher:
         default:
-        description: Agent responsible for making the health data resource 
-          available.
+        description: Agent responsible for making the health data resource available.
         items:
           anyOf:
           - format: uri
@@ -2429,15 +2368,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -2475,15 +2413,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -2494,8 +2431,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -2524,8 +2461,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -2535,8 +2472,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -2550,8 +2487,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -2562,8 +2499,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -2572,8 +2509,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -2582,8 +2519,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -2648,8 +2585,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -2667,8 +2604,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -2680,8 +2617,8 @@ $defs:
         title: Was Generated By
         type: array
       applicable_legislation:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -2725,8 +2662,7 @@ $defs:
         type: array
       coding_system:
         default:
-        description: Health classifications and their codes associated with the 
-          dataset
+        description: Health classifications and their codes associated with the dataset
         items:
           format: uri
           minLength: 1
@@ -2763,15 +2699,14 @@ $defs:
           type: string
         - $ref: '#/$defs/HEALTHDCATAPHdab'
         default:
-        description: Health Data Access Body supporting access to data in the 
-          Member State.
+        description: Health Data Access Body supporting access to data in the Member
+          State.
         rdf_term: http://healthdataportal.eu/ns/health#hdab
         rdf_type: uri
         title: Hdab
       legal_basis:
         default:
-        description: The legal basis used to justify processing of personal 
-          data.
+        description: The legal basis used to justify processing of personal data.
         items:
           format: uri
           minLength: 1
@@ -2830,8 +2765,8 @@ $defs:
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: http://purl.org/dc/terms/PeriodOfTime
     required:
@@ -2857,14 +2792,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -2873,8 +2807,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -2888,9 +2822,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -2914,8 +2847,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -2927,14 +2860,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -2945,8 +2877,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -2966,9 +2898,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -2984,17 +2915,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -3005,8 +2934,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -3022,17 +2951,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -3062,15 +2989,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -3108,15 +3034,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -3127,8 +3052,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -3157,8 +3082,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -3168,8 +3093,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -3183,8 +3108,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -3195,8 +3120,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -3205,8 +3130,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -3215,8 +3140,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -3284,8 +3209,7 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          distribution.
+        description: Date of formal issuance (e.g., publication) of the distribution.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
@@ -3297,15 +3221,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the distribution was changed, 
-          updated or modified.
+        description: Most recent date on which the distribution was changed, updated
+          or modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       license:
         default:
-        description: A legal document under which the distribution is made 
-          available.
+        description: A legal document under which the distribution is made available.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/license
@@ -3314,8 +3237,7 @@ $defs:
         type: string
       access_rights:
         default:
-        description: A rights statement that concerns how the distribution is 
-          accessed.
+        description: A rights statement that concerns how the distribution is accessed.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -3336,13 +3258,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the distribution.
+        description: An ODRL conformant policy expressing the rights associated with
+          the distribution.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       access_url:
-        description: A URL of the resource that gives access to a distribution 
-          of the dataset. E.g., landing page, feed, SPARQL endpoint.
+        description: A URL of the resource that gives access to a distribution of
+          the dataset. E.g., landing page, feed, SPARQL endpoint.
         items:
           format: uri
           minLength: 1
@@ -3353,8 +3275,7 @@ $defs:
         type: array
       access_service:
         default:
-        description: A data service that gives access to the distribution of the
-          dataset
+        description: A data service that gives access to the distribution of the dataset
         items:
           anyOf:
           - format: uri
@@ -3367,9 +3288,9 @@ $defs:
         type: array
       download_url:
         default:
-        description: The URL of the downloadable file in a given format. E.g., 
-          CSV file or RDF file. The format is indicated by the distribution's 
-          dcterms:format and/or dcat:mediaType
+        description: The URL of the downloadable file in a given format. E.g., CSV
+          file or RDF file. The format is indicated by the distribution's dcterms:format
+          and/or dcat:mediaType
         items:
           format: uri
           minLength: 1
@@ -3392,8 +3313,8 @@ $defs:
         - type: number
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Minimum spatial separation resolvable in a dataset 
-          distribution, measured in meters.
+        description: Minimum spatial separation resolvable in a dataset distribution,
+          measured in meters.
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
         rdf_type: xsd:decimal
         title: Spatial Resolution
@@ -3403,7 +3324,7 @@ $defs:
         - $ref: '#/$defs/LiteralField'
         default:
         description: Minimum time period resolvable in the dataset.
-        rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
+        rdf_term: http://www.w3.org/ns/dcat#temporalResolution
         rdf_type: xsd:duration
         title: Temporal Resolution
       conforms_to:
@@ -3437,9 +3358,9 @@ $defs:
         type: string
       compression_format:
         default:
-        description: The compression format of the distribution in which the 
-          data is contained in a compressed form, e.g., to reduce the size of 
-          the downloadable file.
+        description: The compression format of the distribution in which the data
+          is contained in a compressed form, e.g., to reduce the size of the downloadable
+          file.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#compressFormat
@@ -3448,9 +3369,9 @@ $defs:
         type: string
       packaging_format:
         default:
-        description: The package format of the distribution in which one or more
-          data files are grouped together, e.g., to enable a set of related 
-          files to be downloaded together.
+        description: The package format of the distribution in which one or more data
+          files are grouped together, e.g., to enable a set of related files to be
+          downloaded together.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#packageFormat
@@ -3460,9 +3381,8 @@ $defs:
       checksum:
         $ref: '#/$defs/Checksum'
         default:
-        description: The checksum property provides a mechanism that can be used
-          to verify that the contents of a file or package have not changed 
-          [SPDX].
+        description: The checksum property provides a mechanism that can be used to
+          verify that the contents of a file or package have not changed [SPDX].
         rdf_term: http://spdx.org/rdf/terms#checksum
         rdf_type: uri
       retention_period:
@@ -3472,8 +3392,8 @@ $defs:
           type: string
         - $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: uri
         title: Retention Period
@@ -3502,8 +3422,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Health Data Access Body supporting access to data in the Member
-      State.
+    description: Health Data Access Body supporting access to data in the Member State.
     properties:
       name:
         description: A name of the agent
@@ -3525,8 +3444,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -3537,8 +3456,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -3587,8 +3506,8 @@ $defs:
         type: string
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -3608,8 +3527,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact or provides 
-          information on how to get in touch.
+        description: A webpage that either allows to make contact or provides information
+          on how to get in touch.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasURL
@@ -3626,8 +3545,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Agent responsible for making the health data resource 
-      available.
+    description: Agent responsible for making the health data resource available.
     properties:
       name:
         description: A name of the agent
@@ -3649,8 +3567,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -3661,8 +3579,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -3720,8 +3638,7 @@ $defs:
         title: Name
         type: array
       identifier:
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         items:
           anyOf:
           - type: string
@@ -3807,14 +3724,13 @@ $defs:
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -3857,8 +3773,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -3870,23 +3786,22 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         rdf_term: http://purl.org/dc/terms/identifier
         rdf_type: rdfs_literal
         title: Identifier
       is_referenced_by:
         default:
-        description: A related resource that references, cites, or otherwise 
-          points to the described resource.
+        description: A related resource that references, cites, or otherwise points
+          to the described resource.
         items:
           format: uri
           minLength: 1
@@ -3905,9 +3820,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -3923,17 +3837,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -3944,8 +3856,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -3961,17 +3873,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource.
+        description: Link to a description of a relationship with another resource.
         items:
           anyOf:
           - format: uri
@@ -4000,14 +3910,13 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           $ref: '#/$defs/DatasetTheme'
         rdf_term: http://www.w3.org/ns/dcat#theme
@@ -4043,8 +3952,8 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
@@ -4063,8 +3972,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -4093,8 +4002,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -4104,8 +4013,8 @@ $defs:
       status:
         $ref: '#/$defs/DatasetStatus'
         default:
-        description: The status of the Asset in the context of a particular 
-          workflow process.
+        description: The status of the Asset in the context of a particular workflow
+          process.
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -4119,8 +4028,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -4131,8 +4040,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -4141,8 +4050,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -4151,8 +4060,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -4220,8 +4129,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -4239,8 +4148,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -4263,9 +4172,9 @@ $defs:
         type: array
       other_identifier:
         default:
-        description: Links a resource to an adms:Identifier class. Examples for 
-          secondary identifiers are MAST/ADS, DataCite, DOI, EZID or W3ID (if 
-          not used for the original identifier).
+        description: Links a resource to an adms:Identifier class. Examples for secondary
+          identifiers are MAST/ADS, DataCite, DOI, EZID or W3ID (if not used for the
+          original identifier).
         items:
           $ref: '#/$defs/Identifier'
         rdf_term: http://www.w3.org/ns/adms#identifier
@@ -4298,8 +4207,7 @@ $defs:
         type: array
       coding_system:
         default:
-        description: Health classifications and their codes associated with the 
-          dataset
+        description: Health classifications and their codes associated with the dataset
         items:
           format: uri
           minLength: 1
@@ -4336,8 +4244,8 @@ $defs:
           type: string
         - $ref: '#/$defs/HEALTHDCATAPHdab'
         default:
-        description: Health Data Access Body supporting access to data in the 
-          Member State.
+        description: Health Data Access Body supporting access to data in the Member
+          State.
         rdf_term: http://healthdataportal.eu/ns/health#hdab
         rdf_type: uri
         title: Hdab
@@ -4402,8 +4310,8 @@ $defs:
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: http://purl.org/dc/terms/PeriodOfTime
       documentation:
@@ -4467,8 +4375,7 @@ $defs:
         type: array
       source:
         default:
-        description: A related resource from which the described resource is 
-          derived.
+        description: A related resource from which the described resource is derived.
         items:
           anyOf:
           - format: uri
@@ -4506,8 +4413,8 @@ $defs:
       Group)"
     properties:
       hasEmail:
-        description: To specify the electronic mail address for communication 
-          with the object.
+        description: To specify the electronic mail address for communication with
+          the object.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasEmail
@@ -4533,8 +4440,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact (e.g. a 
-          webform) or provides information on how to get in touch.
+        description: A webpage that either allows to make contact (e.g. a webform)
+          or provides information on how to get in touch.
         items:
           format: uri
           minLength: 1
@@ -4559,8 +4466,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -4582,7 +4489,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -4593,8 +4500,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -4626,8 +4532,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -4643,8 +4548,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -4698,8 +4602,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -4710,8 +4614,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -4744,8 +4648,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -4756,8 +4660,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -4768,9 +4672,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -4781,8 +4685,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -4877,8 +4781,8 @@ $defs:
         type: string
       body:
         default:
-        description: The object of the relationship is a resource that is a body
-          of the Annotation.
+        description: The object of the relationship is a resource that is a body of
+          the Annotation.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/oa#hasBody
@@ -4889,8 +4793,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -4902,8 +4805,8 @@ $defs:
     additionalProperties: false
     properties:
       had_role:
-        description: The function of an entity or agent with respect to another 
-          entity or resource.
+        description: The function of an entity or agent with respect to another entity
+          or resource.
         items:
           format: uri
           minLength: 1
@@ -4941,11 +4844,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -4954,9 +4856,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -4965,10 +4867,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -4977,9 +4878,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -4988,12 +4889,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -5001,11 +4901,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -5041,8 +4940,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -5050,8 +4948,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -5060,8 +4958,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -5078,15 +4975,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -5103,23 +4999,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -5153,8 +5049,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -5178,19 +5074,18 @@ $namespace: http://www.w3.org/ns/dcat#
 $ontology: https://www.w3.org/TR/vocab-dcat-3/
 $prefix: dcat
 additionalProperties: false
-description: A collection of operations that provides access to one or more 
-  datasets or data processing functions.
+description: A collection of operations that provides access to one or more datasets
+  or data processing functions.
 properties:
   access_rights:
     $ref: '#/$defs/AccessRights'
-    description: Information about who access the resource or an indication of 
-      its security status.
+    description: Information about who access the resource or an indication of its
+      security status.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/conformsTo
@@ -5232,8 +5127,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -5245,23 +5140,22 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     anyOf:
     - type: string
     - $ref: '#/$defs/LiteralField'
-    description: An unambiguous reference to the resource within a given 
-      context.
+    description: An unambiguous reference to the resource within a given context.
     rdf_term: http://purl.org/dc/terms/identifier
     rdf_type: rdfs_literal
     title: Identifier
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -5281,9 +5175,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -5298,17 +5191,16 @@ properties:
       minLength: 1
       type: string
     - $ref: '#/$defs/GeonovumLicences'
-    description: A legal document giving official permission to do something 
-      with the resource.
+    description: A legal document giving official permission to do something with
+      the resource.
     rdf_term: http://purl.org/dc/terms/license
     rdf_type: uri
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -5319,8 +5211,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -5374,8 +5265,7 @@ properties:
     rdf_type: datetime_literal
     title: Release Date
   theme:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       $ref: '#/$defs/DatasetTheme'
     rdf_term: http://www.w3.org/ns/dcat#theme
@@ -5411,15 +5301,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -5430,8 +5318,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -5460,8 +5348,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -5471,8 +5359,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -5486,8 +5374,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -5498,8 +5386,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -5508,8 +5396,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -5518,8 +5406,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -5551,8 +5439,8 @@ properties:
     title: Geographical Coverage
     type: array
   endpoint_description:
-    description: A description of the services available via the end-points, 
-      including their operations, parameters etc.
+    description: A description of the services available via the end-points, including
+      their operations, parameters etc.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#endpointDescription
@@ -5560,8 +5448,8 @@ properties:
     title: Endpoint Description
     type: string
   endpoint_url:
-    description: The root location or primary endpoint of the service (a 
-      Web-resolvable IRI).
+    description: The root location or primary endpoint of the service (a Web-resolvable
+      IRI).
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#endpointURL
@@ -5594,8 +5482,7 @@ properties:
     type: array
   application_profile:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     items:
       format: uri
       minLength: 1
@@ -5606,8 +5493,7 @@ properties:
     type: array
   format:
     default:
-    description: The file format, physical medium, or dimensions of the 
-      resource.
+    description: The file format, physical medium, or dimensions of the resource.
     items:
       format: uri
       minLength: 1
@@ -5618,8 +5504,7 @@ properties:
     type: array
   hvd_category:
     default:
-    description: A data category defined in the High Value Dataset Implementing 
-      Regulation.
+    description: A data category defined in the High Value Dataset Implementing Regulation.
     items:
       format: uri
       minLength: 1

--- a/models/hri_dcat/HRIDataset.json
+++ b/models/hri_dcat/HRIDataset.json
@@ -4063,7 +4063,7 @@
           ],
           "default": null,
           "description": "Minimum time period resolvable in the dataset.",
-          "rdf_term": "http://www.w3.org/ns/dcat#spatialResolutionInMeters",
+          "rdf_term": "http://www.w3.org/ns/dcat#temporalResolution",
           "rdf_type": "xsd:duration",
           "title": "Temporal Resolution"
         },

--- a/models/hri_dcat/HRIDataset.yaml
+++ b/models/hri_dcat/HRIDataset.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -354,15 +344,15 @@ $defs:
           type: string
         - $ref: '#/$defs/Agent'
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource.
         rdf_term: http://www.w3.org/ns/prov#agent
         rdf_type: uri
         title: Agent
       role:
         default:
-        description: The function of an entity or agent with respect to another 
-          entity or resource.
+        description: The function of an entity or agent with respect to another entity
+          or resource.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hadRole
@@ -377,10 +367,10 @@ $defs:
     $ontology: http://spdx.org/rdf/terms/2.3
     $prefix: spdx
     additionalProperties: false
-    description: "A Checksum is value that allows the contents of a file to be authenticated.\
-      \ \nEven small changes to the content of the file will change its checksum.\
-      \ \nThis class allows the results of a variety of checksum and cryptographic
-      message digest algorithms to be \nrepresented."
+    description: "A Checksum is value that allows the contents of a file to be authenticated.
+      \nEven small changes to the content of the file will change its checksum. \n
+      This class allows the results of a variety of checksum and cryptographic message
+      digest algorithms to be \nrepresented."
     properties:
       algorithm:
         description: The algorithm used to produce the subject Checksum.
@@ -394,8 +384,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A lower case hexadecimal encoded digest value produced 
-          using a specific algorithm.
+        description: A lower case hexadecimal encoded digest value produced using
+          a specific algorithm.
         rdf_term: http://spdx.org/rdf/terms#checksumValue
         rdf_type: xsd:hexBinary
         title: Checksum Value
@@ -410,20 +400,19 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -432,8 +421,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -447,9 +436,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -473,8 +461,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -486,14 +474,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -504,8 +491,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -525,9 +512,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -543,17 +529,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -564,8 +548,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -581,17 +565,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -621,15 +603,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -667,15 +648,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -686,8 +666,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -716,8 +696,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -727,8 +707,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -742,8 +722,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -754,8 +734,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -764,8 +744,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -774,8 +754,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -808,8 +788,8 @@ $defs:
         type: array
       endpoint_description:
         default:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         items:
           anyOf:
           - format: uri
@@ -821,8 +801,8 @@ $defs:
         title: Endpoint Description
         type: array
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         items:
           anyOf:
           - format: uri
@@ -866,15 +846,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -885,8 +863,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -900,9 +878,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -926,8 +903,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -939,14 +916,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -957,8 +933,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -978,9 +954,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -996,17 +971,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1017,8 +990,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1034,17 +1007,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1074,15 +1045,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1120,15 +1090,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1139,8 +1108,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1169,8 +1138,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1180,8 +1149,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1195,8 +1164,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1207,8 +1176,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1217,8 +1186,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1227,8 +1196,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1294,8 +1263,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -1313,8 +1282,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -1327,8 +1296,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -1362,14 +1331,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -1378,8 +1346,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -1393,9 +1361,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -1419,8 +1386,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -1432,14 +1399,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -1450,8 +1416,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -1471,9 +1437,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -1489,17 +1454,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1510,8 +1473,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1527,17 +1490,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1567,15 +1528,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1613,15 +1573,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1632,8 +1591,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1662,8 +1621,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1673,8 +1632,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1688,8 +1647,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1700,8 +1659,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1710,8 +1669,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1720,8 +1679,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1799,11 +1758,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1812,9 +1770,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1823,10 +1781,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1835,9 +1792,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1846,12 +1803,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1859,11 +1815,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1899,8 +1854,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1912,8 +1867,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1921,8 +1876,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1931,27 +1886,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -1997,8 +1952,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -2007,8 +1961,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -2030,26 +1983,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -2066,8 +2018,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -2082,25 +2033,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -2110,8 +2060,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -2146,8 +2095,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -2158,8 +2107,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2190,8 +2139,7 @@ $defs:
     additionalProperties: false
     properties:
       access_rights:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -2200,8 +2148,7 @@ $defs:
         type: string
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -2211,8 +2158,8 @@ $defs:
         title: Conforms To
         type: array
       contact_point:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - $ref: '#/$defs/HEALTHDCATAPKind'
@@ -2225,9 +2172,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - $ref: '#/$defs/HEALTHDCATAPAgent'
@@ -2250,8 +2196,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -2263,13 +2209,12 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -2280,8 +2225,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -2301,9 +2246,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -2319,17 +2263,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -2340,8 +2282,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -2357,17 +2299,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -2378,8 +2318,7 @@ $defs:
         type: array
       publisher:
         default:
-        description: Agent responsible for making the health data resource 
-          available.
+        description: Agent responsible for making the health data resource available.
         items:
           anyOf:
           - format: uri
@@ -2398,15 +2337,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -2444,15 +2382,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -2463,8 +2400,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -2493,8 +2430,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -2504,8 +2441,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -2519,8 +2456,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -2531,8 +2468,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -2541,8 +2478,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -2551,8 +2488,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -2617,8 +2554,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -2636,8 +2573,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -2649,8 +2586,8 @@ $defs:
         title: Was Generated By
         type: array
       applicable_legislation:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -2694,8 +2631,7 @@ $defs:
         type: array
       coding_system:
         default:
-        description: Health classifications and their codes associated with the 
-          dataset
+        description: Health classifications and their codes associated with the dataset
         items:
           format: uri
           minLength: 1
@@ -2732,15 +2668,14 @@ $defs:
           type: string
         - $ref: '#/$defs/HEALTHDCATAPHdab'
         default:
-        description: Health Data Access Body supporting access to data in the 
-          Member State.
+        description: Health Data Access Body supporting access to data in the Member
+          State.
         rdf_term: http://healthdataportal.eu/ns/health#hdab
         rdf_type: uri
         title: Hdab
       legal_basis:
         default:
-        description: The legal basis used to justify processing of personal 
-          data.
+        description: The legal basis used to justify processing of personal data.
         items:
           format: uri
           minLength: 1
@@ -2799,8 +2734,8 @@ $defs:
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: http://purl.org/dc/terms/PeriodOfTime
     required:
@@ -2826,14 +2761,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -2842,8 +2776,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -2857,9 +2791,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -2883,8 +2816,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -2896,14 +2829,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -2914,8 +2846,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -2935,9 +2867,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -2953,17 +2884,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -2974,8 +2903,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -2991,17 +2920,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -3031,15 +2958,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -3077,15 +3003,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -3096,8 +3021,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -3126,8 +3051,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -3137,8 +3062,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -3152,8 +3077,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -3164,8 +3089,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -3174,8 +3099,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -3184,8 +3109,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -3253,8 +3178,7 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          distribution.
+        description: Date of formal issuance (e.g., publication) of the distribution.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
@@ -3266,15 +3190,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the distribution was changed, 
-          updated or modified.
+        description: Most recent date on which the distribution was changed, updated
+          or modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       license:
         default:
-        description: A legal document under which the distribution is made 
-          available.
+        description: A legal document under which the distribution is made available.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/license
@@ -3283,8 +3206,7 @@ $defs:
         type: string
       access_rights:
         default:
-        description: A rights statement that concerns how the distribution is 
-          accessed.
+        description: A rights statement that concerns how the distribution is accessed.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -3305,13 +3227,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the distribution.
+        description: An ODRL conformant policy expressing the rights associated with
+          the distribution.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       access_url:
-        description: A URL of the resource that gives access to a distribution 
-          of the dataset. E.g., landing page, feed, SPARQL endpoint.
+        description: A URL of the resource that gives access to a distribution of
+          the dataset. E.g., landing page, feed, SPARQL endpoint.
         items:
           format: uri
           minLength: 1
@@ -3322,8 +3244,7 @@ $defs:
         type: array
       access_service:
         default:
-        description: A data service that gives access to the distribution of the
-          dataset
+        description: A data service that gives access to the distribution of the dataset
         items:
           anyOf:
           - format: uri
@@ -3336,9 +3257,9 @@ $defs:
         type: array
       download_url:
         default:
-        description: The URL of the downloadable file in a given format. E.g., 
-          CSV file or RDF file. The format is indicated by the distribution's 
-          dcterms:format and/or dcat:mediaType
+        description: The URL of the downloadable file in a given format. E.g., CSV
+          file or RDF file. The format is indicated by the distribution's dcterms:format
+          and/or dcat:mediaType
         items:
           format: uri
           minLength: 1
@@ -3361,8 +3282,8 @@ $defs:
         - type: number
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Minimum spatial separation resolvable in a dataset 
-          distribution, measured in meters.
+        description: Minimum spatial separation resolvable in a dataset distribution,
+          measured in meters.
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
         rdf_type: xsd:decimal
         title: Spatial Resolution
@@ -3372,7 +3293,7 @@ $defs:
         - $ref: '#/$defs/LiteralField'
         default:
         description: Minimum time period resolvable in the dataset.
-        rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
+        rdf_term: http://www.w3.org/ns/dcat#temporalResolution
         rdf_type: xsd:duration
         title: Temporal Resolution
       conforms_to:
@@ -3406,9 +3327,9 @@ $defs:
         type: string
       compression_format:
         default:
-        description: The compression format of the distribution in which the 
-          data is contained in a compressed form, e.g., to reduce the size of 
-          the downloadable file.
+        description: The compression format of the distribution in which the data
+          is contained in a compressed form, e.g., to reduce the size of the downloadable
+          file.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#compressFormat
@@ -3417,9 +3338,9 @@ $defs:
         type: string
       packaging_format:
         default:
-        description: The package format of the distribution in which one or more
-          data files are grouped together, e.g., to enable a set of related 
-          files to be downloaded together.
+        description: The package format of the distribution in which one or more data
+          files are grouped together, e.g., to enable a set of related files to be
+          downloaded together.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#packageFormat
@@ -3429,9 +3350,8 @@ $defs:
       checksum:
         $ref: '#/$defs/Checksum'
         default:
-        description: The checksum property provides a mechanism that can be used
-          to verify that the contents of a file or package have not changed 
-          [SPDX].
+        description: The checksum property provides a mechanism that can be used to
+          verify that the contents of a file or package have not changed [SPDX].
         rdf_term: http://spdx.org/rdf/terms#checksum
         rdf_type: uri
       retention_period:
@@ -3441,8 +3361,8 @@ $defs:
           type: string
         - $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: uri
         title: Retention Period
@@ -3471,8 +3391,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Health Data Access Body supporting access to data in the Member
-      State.
+    description: Health Data Access Body supporting access to data in the Member State.
     properties:
       name:
         description: A name of the agent
@@ -3494,8 +3413,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -3506,8 +3425,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -3556,8 +3475,8 @@ $defs:
         type: string
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -3577,8 +3496,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact or provides 
-          information on how to get in touch.
+        description: A webpage that either allows to make contact or provides information
+          on how to get in touch.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasURL
@@ -3595,8 +3514,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Agent responsible for making the health data resource 
-      available.
+    description: Agent responsible for making the health data resource available.
     properties:
       name:
         description: A name of the agent
@@ -3618,8 +3536,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -3630,8 +3548,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -3689,8 +3607,7 @@ $defs:
         title: Name
         type: array
       identifier:
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         items:
           anyOf:
           - type: string
@@ -3778,8 +3695,8 @@ $defs:
       Group)"
     properties:
       hasEmail:
-        description: To specify the electronic mail address for communication 
-          with the object.
+        description: To specify the electronic mail address for communication with
+          the object.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasEmail
@@ -3805,8 +3722,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact (e.g. a 
-          webform) or provides information on how to get in touch.
+        description: A webpage that either allows to make contact (e.g. a webform)
+          or provides information on how to get in touch.
         items:
           format: uri
           minLength: 1
@@ -3831,8 +3748,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -3854,7 +3771,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -3865,8 +3782,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -3898,8 +3814,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -3915,8 +3830,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -3970,8 +3884,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -3982,8 +3896,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -4016,8 +3930,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -4028,8 +3942,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -4040,9 +3954,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -4053,8 +3967,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -4149,8 +4063,8 @@ $defs:
         type: string
       body:
         default:
-        description: The object of the relationship is a resource that is a body
-          of the Annotation.
+        description: The object of the relationship is a resource that is a body of
+          the Annotation.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/oa#hasBody
@@ -4161,8 +4075,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -4174,8 +4087,8 @@ $defs:
     additionalProperties: false
     properties:
       had_role:
-        description: The function of an entity or agent with respect to another 
-          entity or resource.
+        description: The function of an entity or agent with respect to another entity
+          or resource.
         items:
           format: uri
           minLength: 1
@@ -4213,11 +4126,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -4226,9 +4138,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -4237,10 +4149,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -4249,9 +4160,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -4260,12 +4171,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -4273,11 +4183,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -4313,8 +4222,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -4322,8 +4230,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -4332,8 +4240,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -4350,15 +4257,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -4375,23 +4281,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -4425,8 +4331,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -4455,14 +4361,13 @@ additionalProperties: false
 properties:
   access_rights:
     $ref: '#/$defs/AccessRights'
-    description: Information about who can access the resource or an indication 
-      of its security status.
+    description: Information about who can access the resource or an indication of
+      its security status.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     items:
       format: uri
       minLength: 1
@@ -4505,8 +4410,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -4518,23 +4423,22 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     anyOf:
     - type: string
     - $ref: '#/$defs/LiteralField'
-    description: An unambiguous reference to the resource within a given 
-      context.
+    description: An unambiguous reference to the resource within a given context.
     rdf_term: http://purl.org/dc/terms/identifier
     rdf_type: rdfs_literal
     title: Identifier
   is_referenced_by:
     default:
-    description: A related resource that references, cites, or otherwise points 
-      to the described resource.
+    description: A related resource that references, cites, or otherwise points to
+      the described resource.
     items:
       format: uri
       minLength: 1
@@ -4553,9 +4457,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -4577,10 +4480,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -4591,8 +4493,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -4608,10 +4509,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -4651,8 +4551,7 @@ properties:
     rdf_type: datetime_literal
     title: Release Date
   theme:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       $ref: '#/$defs/DatasetTheme'
     rdf_term: http://www.w3.org/ns/dcat#theme
@@ -4688,8 +4587,7 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
@@ -4708,8 +4606,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -4738,8 +4636,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -4749,8 +4647,7 @@ properties:
   status:
     $ref: '#/$defs/DatasetStatus'
     default:
-    description: The status of the Asset in the context of a particular workflow
-      process.
+    description: The status of the Asset in the context of a particular workflow process.
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -4764,8 +4661,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -4776,8 +4673,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -4786,8 +4683,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -4796,8 +4693,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1
@@ -4865,8 +4762,7 @@ properties:
     type: array
   spatial_resolution:
     default:
-    description: Minimum spatial separation resolvable in a dataset, measured in
-      meters.
+    description: Minimum spatial separation resolvable in a dataset, measured in meters.
     items:
       type: number
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -4884,8 +4780,8 @@ properties:
     title: Temporal Resolution
   was_generated_by:
     default:
-    description: An activity that generated, or provides the business context 
-      for, the creation of the dataset.
+    description: An activity that generated, or provides the business context for,
+      the creation of the dataset.
     items:
       anyOf:
       - format: uri
@@ -4908,9 +4804,9 @@ properties:
     type: array
   other_identifier:
     default:
-    description: Links a resource to an adms:Identifier class. Examples for 
-      secondary identifiers are MAST/ADS, DataCite, DOI, EZID or W3ID (if not 
-      used for the original identifier).
+    description: Links a resource to an adms:Identifier class. Examples for secondary
+      identifiers are MAST/ADS, DataCite, DOI, EZID or W3ID (if not used for the original
+      identifier).
     items:
       $ref: '#/$defs/Identifier'
     rdf_term: http://www.w3.org/ns/adms#identifier
@@ -4943,8 +4839,7 @@ properties:
     type: array
   coding_system:
     default:
-    description: Health classifications and their codes associated with the 
-      dataset
+    description: Health classifications and their codes associated with the dataset
     items:
       format: uri
       minLength: 1
@@ -4981,8 +4876,7 @@ properties:
       type: string
     - $ref: '#/$defs/HEALTHDCATAPHdab'
     default:
-    description: Health Data Access Body supporting access to data in the Member
-      State.
+    description: Health Data Access Body supporting access to data in the Member State.
     rdf_term: http://healthdataportal.eu/ns/health#hdab
     rdf_type: uri
     title: Hdab
@@ -5047,8 +4941,7 @@ properties:
   retention_period:
     $ref: '#/$defs/PeriodOfTime'
     default:
-    description: A temporal period which the dataset is available for secondary 
-      use.
+    description: A temporal period which the dataset is available for secondary use.
     rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
     rdf_type: http://purl.org/dc/terms/PeriodOfTime
   documentation:
@@ -5112,8 +5005,7 @@ properties:
     type: array
   source:
     default:
-    description: A related resource from which the described resource is 
-      derived.
+    description: A related resource from which the described resource is derived.
     items:
       anyOf:
       - format: uri

--- a/models/hri_dcat/HRIDatasetSeries.yaml
+++ b/models/hri_dcat/HRIDatasetSeries.yaml
@@ -34,8 +34,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -46,8 +46,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -65,8 +65,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -78,8 +78,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -87,8 +87,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -97,27 +97,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -163,8 +163,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -173,8 +172,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -196,26 +194,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -232,8 +229,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -248,25 +244,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -276,8 +271,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -288,7 +282,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -299,8 +293,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -332,8 +325,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -349,8 +341,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -404,8 +395,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -416,8 +407,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -450,8 +441,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -462,8 +453,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -474,9 +465,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -487,8 +478,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -567,8 +558,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -599,8 +589,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -608,8 +597,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -618,8 +607,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -636,15 +624,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -661,23 +648,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -711,8 +698,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -742,14 +729,13 @@ properties:
   access_rights:
     $ref: '#/$defs/AccessRights'
     default:
-    description: Information about who can access the resource or an indication 
-      of its security status.
+    description: Information about who can access the resource or an indication of
+      its security status.
     rdf_term: http://purl.org/dc/terms/accessRights
     rdf_type: uri
   conforms_to:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/conformsTo
@@ -770,8 +756,8 @@ properties:
     type: array
   creator:
     default:
-    description: The entity responsible for producing the resource. Resources of
-      type foaf:Agent are recommended as values for this property.
+    description: The entity responsible for producing the resource. Resources of type
+      foaf:Agent are recommended as values for this property.
     items:
       anyOf:
       - format: uri
@@ -795,8 +781,8 @@ properties:
     type: array
   has_part:
     default:
-    description: A related resource that is included either physically or 
-      logically in the described resource.
+    description: A related resource that is included either physically or logically
+      in the described resource.
     items:
       format: uri
       minLength: 1
@@ -808,14 +794,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the resource.
+    description: An ODRL conformant policy expressing the rights associated with the
+      resource.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   identifier:
     default:
-    description: A unique identifier of the resource being described or 
-      cataloged.
+    description: A unique identifier of the resource being described or cataloged.
     items:
       anyOf:
       - type: string
@@ -826,8 +811,8 @@ properties:
     type: array
   is_referenced_by:
     default:
-    description: A related resource, such as a publication, that references, 
-      cites, or otherwise points to the cataloged resource.
+    description: A related resource, such as a publication, that references, cites,
+      or otherwise points to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -847,9 +832,8 @@ properties:
     type: array
   landing_page:
     default:
-    description: A Web page that can be navigated to in a Web browser to gain 
-      access to the catalog, a dataset, its distributions and/or additional 
-      information.
+    description: A Web page that can be navigated to in a Web browser to gain access
+      to the catalog, a dataset, its distributions and/or additional information.
     items:
       format: uri
       minLength: 1
@@ -871,10 +855,9 @@ properties:
     title: License
   language:
     default:
-    description: A language of the resource. This refers to the natural language
-      used for textual metadata (i.e., titles, descriptions, etc.) of a 
-      cataloged resource (i.e., dataset or service) or the textual values of a 
-      dataset distribution
+    description: A language of the resource. This refers to the natural language used
+      for textual metadata (i.e., titles, descriptions, etc.) of a cataloged resource
+      (i.e., dataset or service) or the textual values of a dataset distribution
     items:
       format: uri
       minLength: 1
@@ -885,8 +868,7 @@ properties:
     type: array
   relation:
     default:
-    description: A resource with an unspecified relationship to the cataloged 
-      resource.
+    description: A resource with an unspecified relationship to the cataloged resource.
     items:
       format: uri
       minLength: 1
@@ -902,10 +884,9 @@ properties:
       minLength: 1
       type: string
     default:
-    description: Information about rights held in and over the distribution. 
-      Recommended practice is to refer to a rights statement with a URI. If this
-      is not possible or feasible, a literal value (name, label, or short text) 
-      may be provided.
+    description: Information about rights held in and over the distribution. Recommended
+      practice is to refer to a rights statement with a URI. If this is not possible
+      or feasible, a literal value (name, label, or short text) may be provided.
     rdf_term: http://purl.org/dc/terms/rights
     rdf_type: uri
     title: Rights
@@ -945,8 +926,7 @@ properties:
     title: Release Date
   theme:
     default:
-    description: A main category of the resource. A resource can have multiple 
-      themes.
+    description: A main category of the resource. A resource can have multiple themes.
     items:
       format: uri
       minLength: 1
@@ -984,15 +964,13 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
   qualified_attribution:
     default:
-    description: Link to an Agent having some form of responsibility for the 
-      resource
+    description: Link to an Agent having some form of responsibility for the resource
     items:
       format: uri
       minLength: 1
@@ -1003,8 +981,8 @@ properties:
     type: array
   has_current_version:
     default:
-    description: This resource has a more specific, versioned resource with 
-      equivalent content [PAV].
+    description: This resource has a more specific, versioned resource with equivalent
+      content [PAV].
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1033,8 +1011,8 @@ properties:
     type: string
   replaces:
     default:
-    description: A related resource that is supplanted, displaced, or superseded
-      by the described resource
+    description: A related resource that is supplanted, displaced, or superseded by
+      the described resource
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/replaces
@@ -1044,8 +1022,8 @@ properties:
   status:
     $ref: '#/$defs/Status'
     default:
-    description: The status of the resource in the context of a particular 
-      workflow process [VOCAB-ADMS].
+    description: The status of the resource in the context of a particular workflow
+      process [VOCAB-ADMS].
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
   version:
@@ -1059,8 +1037,8 @@ properties:
     title: Version
   version_notes:
     default:
-    description: A description of changes between this version and the previous 
-      version of the resource [VOCAB-ADMS].
+    description: A description of changes between this version and the previous version
+      of the resource [VOCAB-ADMS].
     items:
       anyOf:
       - type: string
@@ -1071,8 +1049,8 @@ properties:
     type: array
   first:
     default:
-    description: The first resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The first resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#first
@@ -1081,8 +1059,8 @@ properties:
     type: string
   last:
     default:
-    description: The last resource in an ordered collection or series of 
-      resources, to which the current resource belongs.
+    description: The last resource in an ordered collection or series of resources,
+      to which the current resource belongs.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#last
@@ -1091,8 +1069,8 @@ properties:
     type: string
   previous:
     default:
-    description: The previous resource (before the current one) in an ordered 
-      collection or series of resources.
+    description: The previous resource (before the current one) in an ordered collection
+      or series of resources.
     items:
       format: uri
       minLength: 1

--- a/models/hri_dcat/HRIDistribution.json
+++ b/models/hri_dcat/HRIDistribution.json
@@ -4107,7 +4107,7 @@
           ],
           "default": null,
           "description": "Minimum time period resolvable in the dataset.",
-          "rdf_term": "http://www.w3.org/ns/dcat#spatialResolutionInMeters",
+          "rdf_term": "http://www.w3.org/ns/dcat#temporalResolution",
           "rdf_type": "xsd:duration",
           "title": "Temporal Resolution"
         },
@@ -7075,7 +7075,7 @@
       ],
       "default": null,
       "description": "Minimum time period resolvable in the dataset.",
-      "rdf_term": "http://www.w3.org/ns/dcat#spatialResolutionInMeters",
+      "rdf_term": "http://www.w3.org/ns/dcat#temporalResolution",
       "rdf_type": "xsd:duration",
       "title": "Temporal Resolution"
     },

--- a/models/hri_dcat/HRIDistribution.yaml
+++ b/models/hri_dcat/HRIDistribution.yaml
@@ -19,9 +19,9 @@ $defs:
     properties:
       generated:
         default:
-        description: Generation is the completion of production of a new entity 
-          by an activity. This entity did not exist before generation and 
-          becomes available for usage after this generation.
+        description: Generation is the completion of production of a new entity by
+          an activity. This entity did not exist before generation and becomes available
+          for usage after this generation.
         items:
           format: uri
           minLength: 1
@@ -32,11 +32,10 @@ $defs:
         type: array
       qualifiedAssociation:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         items:
           anyOf:
           - format: uri
@@ -49,11 +48,10 @@ $defs:
         type: array
       wasAssociatedWith:
         default:
-        description: An activity association is an assignment of responsibility 
-          to an agent for an activity, indicating that the agent had a role in 
-          the activity. It further allows for a plan to be specified, which is 
-          the plan intended by the agent to achieve some goals in the context of
-          this activity.
+        description: An activity association is an assignment of responsibility to
+          an agent for an activity, indicating that the agent had a role in the activity.
+          It further allows for a plan to be specified, which is the plan intended
+          by the agent to achieve some goals in the context of this activity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -63,22 +61,20 @@ $defs:
       qualifiedEnd:
         $ref: '#/$defs/End'
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
         rdf_type: http://www.w3.org/ns/prov#End
       wasEndedBy:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -87,9 +83,9 @@ $defs:
         type: string
       qualifiedUsage:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         items:
           format: uri
           minLength: 1
@@ -100,9 +96,9 @@ $defs:
         type: array
       used:
         default:
-        description: Usage is the beginning of utilizing an entity by an 
-          activity. Before usage, the activity had not begun to utilize this 
-          entity and could not have been affected by the entity.
+        description: Usage is the beginning of utilizing an entity by an activity.
+          Before usage, the activity had not begun to utilize this entity and could
+          not have been affected by the entity.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#used
@@ -111,10 +107,10 @@ $defs:
         type: string
       invalidated:
         default:
-        description: Invalidation is the start of the destruction, cessation, or
-          expiry of an existing entity by an activity. The entity is no longer 
-          available for use (or further invalidation) after invalidation. Any 
-          generation or usage of an entity precedes its invalidation.
+        description: Invalidation is the start of the destruction, cessation, or expiry
+          of an existing entity by an activity. The entity is no longer available
+          for use (or further invalidation) after invalidation. Any generation or
+          usage of an entity precedes its invalidation.
         items:
           format: uri
           minLength: 1
@@ -125,12 +121,11 @@ $defs:
         type: array
       endedAtTime:
         default:
-        description: End is when an activity is deemed to have been ended by an 
-          entity, known as trigger. The activity no longer exists after its end.
-          Any usage, generation, or invalidation involving an activity precedes 
-          the activity's end. An end may refer to a trigger entity that 
-          terminated the activity, or to an activity, known as ender that 
-          generated the trigger.
+        description: End is when an activity is deemed to have been ended by an entity,
+          known as trigger. The activity no longer exists after its end. Any usage,
+          generation, or invalidation involving an activity precedes the activity's
+          end. An end may refer to a trigger entity that terminated the activity,
+          or to an activity, known as ender that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#endedAtTime
         rdf_type: xsd:dateTime
@@ -139,18 +134,17 @@ $defs:
       qualifiedStart:
         $ref: '#/$defs/Start'
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         rdf_term: http://www.w3.org/ns/prov#qualifiedStart
         rdf_type: http://www.w3.org/ns/prov#Start
       wasInformedBy:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -161,12 +155,11 @@ $defs:
         type: array
       wasStartedBy:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -175,12 +168,11 @@ $defs:
         type: string
       startedAtTime:
         default:
-        description: Start is when an activity is deemed to have been started by
-          an entity, known as trigger. The activity did not exist before its 
-          start. Any usage, generation, or invalidation involving an activity 
-          follows the activity's start. A start may refer to a trigger entity 
-          that set off the activity, or to an activity, known as starter, that 
-          generated the trigger.
+        description: Start is when an activity is deemed to have been started by an
+          entity, known as trigger. The activity did not exist before its start. Any
+          usage, generation, or invalidation involving an activity follows the activity's
+          start. A start may refer to a trigger entity that set off the activity,
+          or to an activity, known as starter, that generated the trigger.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#startedAtTime
         rdf_type: xsd:dateTime
@@ -188,8 +180,8 @@ $defs:
         type: string
       qualifiedCommunication:
         default:
-        description: Communication is the exchange of an entity by two 
-          activities, one activity using the entity generated by the other.
+        description: Communication is the exchange of an entity by two activities,
+          one activity using the entity generated by the other.
         items:
           format: uri
           minLength: 1
@@ -200,10 +192,10 @@ $defs:
         type: array
       wasInfluencedBy:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -214,10 +206,10 @@ $defs:
         type: array
       qualifiedInfluence:
         default:
-        description: Influence is the capacity of an entity, activity, or agent 
-          to have an effect on the character, development, or behavior of 
-          another by means of usage, start, end, generation, invalidation, 
-          communication, derivation, attribution, association, or delegation.
+        description: Influence is the capacity of an entity, activity, or agent to
+          have an effect on the character, development, or behavior of another by
+          means of usage, start, end, generation, invalidation, communication, derivation,
+          attribution, association, or delegation.
         items:
           format: uri
           minLength: 1
@@ -228,11 +220,10 @@ $defs:
         type: array
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -268,8 +259,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -280,8 +271,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -306,8 +297,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -316,9 +307,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -327,11 +318,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -354,15 +344,15 @@ $defs:
           type: string
         - $ref: '#/$defs/Agent'
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource.
         rdf_term: http://www.w3.org/ns/prov#agent
         rdf_type: uri
         title: Agent
       role:
         default:
-        description: The function of an entity or agent with respect to another 
-          entity or resource.
+        description: The function of an entity or agent with respect to another entity
+          or resource.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hadRole
@@ -377,10 +367,10 @@ $defs:
     $ontology: http://spdx.org/rdf/terms/2.3
     $prefix: spdx
     additionalProperties: false
-    description: "A Checksum is value that allows the contents of a file to be authenticated.\
-      \ \nEven small changes to the content of the file will change its checksum.\
-      \ \nThis class allows the results of a variety of checksum and cryptographic
-      message digest algorithms to be \nrepresented."
+    description: "A Checksum is value that allows the contents of a file to be authenticated.
+      \nEven small changes to the content of the file will change its checksum. \n
+      This class allows the results of a variety of checksum and cryptographic message
+      digest algorithms to be \nrepresented."
     properties:
       algorithm:
         description: The algorithm used to produce the subject Checksum.
@@ -394,8 +384,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A lower case hexadecimal encoded digest value produced 
-          using a specific algorithm.
+        description: A lower case hexadecimal encoded digest value produced using
+          a specific algorithm.
         rdf_term: http://spdx.org/rdf/terms#checksumValue
         rdf_type: xsd:hexBinary
         title: Checksum Value
@@ -410,20 +400,19 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -432,8 +421,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -447,9 +436,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -473,8 +461,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -486,14 +474,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -504,8 +491,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -525,9 +512,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -543,17 +529,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -564,8 +548,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -581,17 +565,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -621,15 +603,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -667,15 +648,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -686,8 +666,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -716,8 +696,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -727,8 +707,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -742,8 +722,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -754,8 +734,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -764,8 +744,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -774,8 +754,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -808,8 +788,8 @@ $defs:
         type: array
       endpoint_description:
         default:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         items:
           anyOf:
           - format: uri
@@ -821,8 +801,8 @@ $defs:
         title: Endpoint Description
         type: array
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         items:
           anyOf:
           - format: uri
@@ -866,15 +846,13 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
         title: Access Rights
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -885,8 +863,8 @@ $defs:
         type: array
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -900,9 +878,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -926,8 +903,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -939,14 +916,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -957,8 +933,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -978,9 +954,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -996,17 +971,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1017,8 +990,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1034,17 +1007,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1074,15 +1045,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1120,15 +1090,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1139,8 +1108,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1169,8 +1138,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1180,8 +1149,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1195,8 +1164,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1207,8 +1176,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1217,8 +1186,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1227,8 +1196,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1294,8 +1263,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -1313,8 +1282,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -1327,8 +1296,8 @@ $defs:
         type: array
       applicable_legislation:
         default:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -1362,14 +1331,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -1378,8 +1346,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -1393,9 +1361,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -1419,8 +1386,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -1432,14 +1399,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -1450,8 +1416,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -1471,9 +1437,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -1489,17 +1454,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -1510,8 +1473,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -1527,17 +1490,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -1567,15 +1528,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -1613,15 +1573,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -1632,8 +1591,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -1662,8 +1621,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -1673,8 +1632,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -1688,8 +1647,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -1700,8 +1659,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -1710,8 +1669,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -1720,8 +1679,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -1808,11 +1767,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -1821,9 +1779,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -1832,10 +1790,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -1844,9 +1801,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -1855,12 +1812,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -1868,11 +1824,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -1908,8 +1863,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -1921,8 +1876,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -1930,8 +1885,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -1940,27 +1895,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -2006,8 +1961,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -2016,8 +1970,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -2039,26 +1992,25 @@ $defs:
     properties:
       dimension:
         default:
-        description: The topological dimension of this geometric object, which 
-          must be less than or equal to the coordinate dimension. In 
-          non-homogeneous collections, this is the largest topological dimension
-          of the contained objects.
+        description: The topological dimension of this geometric object, which must
+          be less than or equal to the coordinate dimension. In non-homogeneous collections,
+          this is the largest topological dimension of the contained objects.
         rdf_term: http://www.opengis.net/ont/geosparql#dimension
         rdf_type: xsd:integer
         title: Dimension
         type: integer
       coordinateDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the position
+          of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#coordinateDimension
         rdf_type: xsd:integer
         title: Coordinatedimension
         type: integer
       spatialDimension:
         default:
-        description: The number of measurements or axes needed to describe the 
-          spatial position of this Geometry in a coordinate system.
+        description: The number of measurements or axes needed to describe the spatial
+          position of this Geometry in a coordinate system.
         rdf_term: http://www.opengis.net/ont/geosparql#spatialDimension
         rdf_type: xsd:integer
         title: Spatialdimension
@@ -2075,8 +2027,7 @@ $defs:
       hasMetricSpatialResolution:
         default:
         description: The spatial resolution of a Geometry in meters.
-        rdf_term: 
-          http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
+        rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialResolution
         rdf_type: xsd:double
         title: Hasmetricspatialresolution
         type: number
@@ -2091,25 +2042,24 @@ $defs:
         type: string
       hasMetricSpatialAccuracy:
         default:
-        description: The positional accuracy of the coordinates of a Geometry in
-          meters.
+        description: The positional accuracy of the coordinates of a Geometry in meters.
         rdf_term: http://www.opengis.net/ont/geosparql#hasMetricSpatialAccuracy
         rdf_type: xsd:double
         title: Hasmetricspatialaccuracy
         type: number
       isEmpty:
         default:
-        description: (true) if this geometric object is the empty Geometry. If 
-          true, then this geometric object represents the empty point set for 
-          the coordinate space.
+        description: (true) if this geometric object is the empty Geometry. If true,
+          then this geometric object represents the empty point set for the coordinate
+          space.
         rdf_term: http://www.opengis.net/ont/geosparql#isEmpty
         rdf_type: xsd:boolean
         title: Isempty
         type: boolean
       isSimple:
         default:
-        description: (true) if this geometric object has no anomalous geometric 
-          points, such as self intersection or self tangency.
+        description: (true) if this geometric object has no anomalous geometric points,
+          such as self intersection or self tangency.
         rdf_term: http://www.opengis.net/ont/geosparql#isSimple
         rdf_type: xsd:boolean
         title: Issimple
@@ -2119,8 +2069,7 @@ $defs:
         - type: string
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Connects a Geometry object with its text-based 
-          serialization.
+        description: Connects a Geometry object with its text-based serialization.
         rdf_term: http://www.opengis.net/ont/geosparql#hasSerialization
         rdf_type: rdfs_literal
         title: Hasserialization
@@ -2186,8 +2135,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -2198,8 +2147,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -2230,8 +2179,7 @@ $defs:
     additionalProperties: false
     properties:
       access_rights:
-        description: Information about who can access the dataset and under what
-          conditions.
+        description: Information about who can access the dataset and under what conditions.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -2240,8 +2188,7 @@ $defs:
         type: string
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -2251,8 +2198,8 @@ $defs:
         title: Conforms To
         type: array
       contact_point:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - $ref: '#/$defs/HEALTHDCATAPKind'
@@ -2265,9 +2212,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - $ref: '#/$defs/HEALTHDCATAPAgent'
@@ -2290,8 +2236,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -2303,13 +2249,12 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -2320,8 +2265,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -2341,9 +2286,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -2359,17 +2303,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -2380,8 +2322,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -2397,17 +2339,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -2418,8 +2358,7 @@ $defs:
         type: array
       publisher:
         default:
-        description: Agent responsible for making the health data resource 
-          available.
+        description: Agent responsible for making the health data resource available.
         items:
           anyOf:
           - format: uri
@@ -2438,15 +2377,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -2484,15 +2422,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -2503,8 +2440,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -2533,8 +2470,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -2544,8 +2481,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -2559,8 +2496,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -2571,8 +2508,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -2581,8 +2518,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -2591,8 +2528,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -2657,8 +2594,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -2676,8 +2613,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -2689,8 +2626,8 @@ $defs:
         title: Was Generated By
         type: array
       applicable_legislation:
-        description: The legislation that mandates the creation or management of
-          the dataset.
+        description: The legislation that mandates the creation or management of the
+          dataset.
         items:
           format: uri
           minLength: 1
@@ -2734,8 +2671,7 @@ $defs:
         type: array
       coding_system:
         default:
-        description: Health classifications and their codes associated with the 
-          dataset
+        description: Health classifications and their codes associated with the dataset
         items:
           format: uri
           minLength: 1
@@ -2772,15 +2708,14 @@ $defs:
           type: string
         - $ref: '#/$defs/HEALTHDCATAPHdab'
         default:
-        description: Health Data Access Body supporting access to data in the 
-          Member State.
+        description: Health Data Access Body supporting access to data in the Member
+          State.
         rdf_term: http://healthdataportal.eu/ns/health#hdab
         rdf_type: uri
         title: Hdab
       legal_basis:
         default:
-        description: The legal basis used to justify processing of personal 
-          data.
+        description: The legal basis used to justify processing of personal data.
         items:
           format: uri
           minLength: 1
@@ -2839,8 +2774,8 @@ $defs:
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: http://purl.org/dc/terms/PeriodOfTime
     required:
@@ -2866,14 +2801,13 @@ $defs:
       access_rights:
         $ref: '#/$defs/AccessRights'
         default:
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -2882,8 +2816,8 @@ $defs:
         type: string
       contact_point:
         default:
-        description: Relevant contact information for the cataloged resource. 
-          Use of vCard is recommended
+        description: Relevant contact information for the cataloged resource. Use
+          of vCard is recommended
         items:
           anyOf:
           - format: uri
@@ -2897,9 +2831,8 @@ $defs:
         type: array
       creator:
         default:
-        description: The entity responsible for producing the resource. 
-          Resources of type foaf:Agent are recommended as values for this 
-          property.
+        description: The entity responsible for producing the resource. Resources
+          of type foaf:Agent are recommended as values for this property.
         items:
           anyOf:
           - format: uri
@@ -2923,8 +2856,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -2936,14 +2869,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         default:
-        description: A unique identifier of the resource being described or 
-          cataloged.
+        description: A unique identifier of the resource being described or cataloged.
         items:
           anyOf:
           - type: string
@@ -2954,8 +2886,8 @@ $defs:
         type: array
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -2975,9 +2907,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -2993,17 +2924,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -3014,8 +2943,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -3031,17 +2960,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -3071,15 +2998,14 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
         default:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           format: uri
           minLength: 1
@@ -3117,15 +3043,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -3136,8 +3061,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -3166,8 +3091,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -3177,8 +3102,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -3192,8 +3117,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -3204,8 +3129,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -3214,8 +3139,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -3224,8 +3149,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -3293,8 +3218,7 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          distribution.
+        description: Date of formal issuance (e.g., publication) of the distribution.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
@@ -3306,15 +3230,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the distribution was changed, 
-          updated or modified.
+        description: Most recent date on which the distribution was changed, updated
+          or modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       license:
         default:
-        description: A legal document under which the distribution is made 
-          available.
+        description: A legal document under which the distribution is made available.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/license
@@ -3323,8 +3246,7 @@ $defs:
         type: string
       access_rights:
         default:
-        description: A rights statement that concerns how the distribution is 
-          accessed.
+        description: A rights statement that concerns how the distribution is accessed.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/accessRights
@@ -3345,13 +3267,13 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the distribution.
+        description: An ODRL conformant policy expressing the rights associated with
+          the distribution.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       access_url:
-        description: A URL of the resource that gives access to a distribution 
-          of the dataset. E.g., landing page, feed, SPARQL endpoint.
+        description: A URL of the resource that gives access to a distribution of
+          the dataset. E.g., landing page, feed, SPARQL endpoint.
         items:
           format: uri
           minLength: 1
@@ -3362,8 +3284,7 @@ $defs:
         type: array
       access_service:
         default:
-        description: A data service that gives access to the distribution of the
-          dataset
+        description: A data service that gives access to the distribution of the dataset
         items:
           anyOf:
           - format: uri
@@ -3376,9 +3297,9 @@ $defs:
         type: array
       download_url:
         default:
-        description: The URL of the downloadable file in a given format. E.g., 
-          CSV file or RDF file. The format is indicated by the distribution's 
-          dcterms:format and/or dcat:mediaType
+        description: The URL of the downloadable file in a given format. E.g., CSV
+          file or RDF file. The format is indicated by the distribution's dcterms:format
+          and/or dcat:mediaType
         items:
           format: uri
           minLength: 1
@@ -3401,8 +3322,8 @@ $defs:
         - type: number
         - $ref: '#/$defs/LiteralField'
         default:
-        description: Minimum spatial separation resolvable in a dataset 
-          distribution, measured in meters.
+        description: Minimum spatial separation resolvable in a dataset distribution,
+          measured in meters.
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
         rdf_type: xsd:decimal
         title: Spatial Resolution
@@ -3412,7 +3333,7 @@ $defs:
         - $ref: '#/$defs/LiteralField'
         default:
         description: Minimum time period resolvable in the dataset.
-        rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
+        rdf_term: http://www.w3.org/ns/dcat#temporalResolution
         rdf_type: xsd:duration
         title: Temporal Resolution
       conforms_to:
@@ -3446,9 +3367,9 @@ $defs:
         type: string
       compression_format:
         default:
-        description: The compression format of the distribution in which the 
-          data is contained in a compressed form, e.g., to reduce the size of 
-          the downloadable file.
+        description: The compression format of the distribution in which the data
+          is contained in a compressed form, e.g., to reduce the size of the downloadable
+          file.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#compressFormat
@@ -3457,9 +3378,9 @@ $defs:
         type: string
       packaging_format:
         default:
-        description: The package format of the distribution in which one or more
-          data files are grouped together, e.g., to enable a set of related 
-          files to be downloaded together.
+        description: The package format of the distribution in which one or more data
+          files are grouped together, e.g., to enable a set of related files to be
+          downloaded together.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#packageFormat
@@ -3469,9 +3390,8 @@ $defs:
       checksum:
         $ref: '#/$defs/Checksum'
         default:
-        description: The checksum property provides a mechanism that can be used
-          to verify that the contents of a file or package have not changed 
-          [SPDX].
+        description: The checksum property provides a mechanism that can be used to
+          verify that the contents of a file or package have not changed [SPDX].
         rdf_term: http://spdx.org/rdf/terms#checksum
         rdf_type: uri
       retention_period:
@@ -3481,8 +3401,8 @@ $defs:
           type: string
         - $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: uri
         title: Retention Period
@@ -3511,8 +3431,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Health Data Access Body supporting access to data in the Member
-      State.
+    description: Health Data Access Body supporting access to data in the Member State.
     properties:
       name:
         description: A name of the agent
@@ -3534,8 +3453,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -3546,8 +3465,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -3596,8 +3515,8 @@ $defs:
         type: string
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -3617,8 +3536,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact or provides 
-          information on how to get in touch.
+        description: A webpage that either allows to make contact or provides information
+          on how to get in touch.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasURL
@@ -3635,8 +3554,7 @@ $defs:
     - https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-6/
     $prefix: foaf
     additionalProperties: false
-    description: Agent responsible for making the health data resource 
-      available.
+    description: Agent responsible for making the health data resource available.
     properties:
       name:
         description: A name of the agent
@@ -3658,8 +3576,8 @@ $defs:
         title: Identifier
       mbox:
         default:
-        description: A personal mailbox, ie. an Internet mailbox associated with
-          exactly one owner, the first owner of this mailbox.
+        description: A personal mailbox, ie. an Internet mailbox associated with exactly
+          one owner, the first owner of this mailbox.
         items:
           format: uri
           minLength: 1
@@ -3670,8 +3588,8 @@ $defs:
         type: array
       homepage:
         default:
-        description: A webpage that either allows to make contact (i.e. a 
-          webform) or the information contains how to get into contact.
+        description: A webpage that either allows to make contact (i.e. a webform)
+          or the information contains how to get into contact.
         format: uri
         minLength: 1
         rdf_term: http://xmlns.com/foaf/0.1/homepage
@@ -3729,8 +3647,7 @@ $defs:
         title: Name
         type: array
       identifier:
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         items:
           anyOf:
           - type: string
@@ -3811,19 +3728,18 @@ $defs:
     $ontology: https://www.w3.org/TR/vocab-dcat-3/
     $prefix: dcat
     additionalProperties: false
-    description: A collection of operations that provides access to one or more 
-      datasets or data processing functions.
+    description: A collection of operations that provides access to one or more datasets
+      or data processing functions.
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
-        description: Information about who access the resource or an indication 
-          of its security status.
+        description: Information about who access the resource or an indication of
+          its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/conformsTo
@@ -3865,8 +3781,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -3878,23 +3794,22 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         rdf_term: http://purl.org/dc/terms/identifier
         rdf_type: rdfs_literal
         title: Identifier
       is_referenced_by:
         default:
-        description: A related resource, such as a publication, that references,
-          cites, or otherwise points to the cataloged resource.
+        description: A related resource, such as a publication, that references, cites,
+          or otherwise points to the cataloged resource.
         items:
           format: uri
           minLength: 1
@@ -3914,9 +3829,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -3931,17 +3845,16 @@ $defs:
           minLength: 1
           type: string
         - $ref: '#/$defs/GeonovumLicences'
-        description: A legal document giving official permission to do something
-          with the resource.
+        description: A legal document giving official permission to do something with
+          the resource.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -3952,8 +3865,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -3975,8 +3888,7 @@ $defs:
         type: array
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource
+        description: Link to a description of a relationship with another resource
         items:
           format: uri
           minLength: 1
@@ -4003,14 +3915,13 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           $ref: '#/$defs/DatasetTheme'
         rdf_term: http://www.w3.org/ns/dcat#theme
@@ -4046,15 +3957,14 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
       qualified_attribution:
         default:
-        description: Link to an Agent having some form of responsibility for the
-          resource
+        description: Link to an Agent having some form of responsibility for the resource
         items:
           format: uri
           minLength: 1
@@ -4065,8 +3975,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -4095,8 +4005,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -4106,8 +4016,8 @@ $defs:
       status:
         $ref: '#/$defs/Status'
         default:
-        description: The status of the resource in the context of a particular 
-          workflow process [VOCAB-ADMS].
+        description: The status of the resource in the context of a particular workflow
+          process [VOCAB-ADMS].
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -4121,8 +4031,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -4133,8 +4043,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -4143,8 +4053,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -4153,8 +4063,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -4186,8 +4096,8 @@ $defs:
         title: Geographical Coverage
         type: array
       endpoint_description:
-        description: A description of the services available via the end-points,
-          including their operations, parameters etc.
+        description: A description of the services available via the end-points, including
+          their operations, parameters etc.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#endpointDescription
@@ -4195,8 +4105,8 @@ $defs:
         title: Endpoint Description
         type: string
       endpoint_url:
-        description: The root location or primary endpoint of the service (a 
-          Web-resolvable IRI).
+        description: The root location or primary endpoint of the service (a Web-resolvable
+          IRI).
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#endpointURL
@@ -4229,8 +4139,7 @@ $defs:
         type: array
       application_profile:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -4241,8 +4150,7 @@ $defs:
         type: array
       format:
         default:
-        description: The file format, physical medium, or dimensions of the 
-          resource.
+        description: The file format, physical medium, or dimensions of the resource.
         items:
           format: uri
           minLength: 1
@@ -4253,8 +4161,8 @@ $defs:
         type: array
       hvd_category:
         default:
-        description: A data category defined in the High Value Dataset 
-          Implementing Regulation.
+        description: A data category defined in the High Value Dataset Implementing
+          Regulation.
         items:
           format: uri
           minLength: 1
@@ -4300,14 +4208,13 @@ $defs:
     properties:
       access_rights:
         $ref: '#/$defs/AccessRights'
-        description: Information about who can access the resource or an 
-          indication of its security status.
+        description: Information about who can access the resource or an indication
+          of its security status.
         rdf_term: http://purl.org/dc/terms/accessRights
         rdf_type: uri
       conforms_to:
         default:
-        description: An established standard to which the described resource 
-          conforms.
+        description: An established standard to which the described resource conforms.
         items:
           format: uri
           minLength: 1
@@ -4350,8 +4257,8 @@ $defs:
         type: array
       has_part:
         default:
-        description: A related resource that is included either physically or 
-          logically in the described resource.
+        description: A related resource that is included either physically or logically
+          in the described resource.
         items:
           format: uri
           minLength: 1
@@ -4363,23 +4270,22 @@ $defs:
       has_policy:
         $ref: '#/$defs/ODRLPolicy'
         default:
-        description: An ODRL conformant policy expressing the rights associated 
-          with the resource.
+        description: An ODRL conformant policy expressing the rights associated with
+          the resource.
         rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
         rdf_type: uri
       identifier:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: An unambiguous reference to the resource within a given 
-          context.
+        description: An unambiguous reference to the resource within a given context.
         rdf_term: http://purl.org/dc/terms/identifier
         rdf_type: rdfs_literal
         title: Identifier
       is_referenced_by:
         default:
-        description: A related resource that references, cites, or otherwise 
-          points to the described resource.
+        description: A related resource that references, cites, or otherwise points
+          to the described resource.
         items:
           format: uri
           minLength: 1
@@ -4398,9 +4304,8 @@ $defs:
         type: array
       landing_page:
         default:
-        description: A Web page that can be navigated to in a Web browser to 
-          gain access to the catalog, a dataset, its distributions and/or 
-          additional information.
+        description: A Web page that can be navigated to in a Web browser to gain
+          access to the catalog, a dataset, its distributions and/or additional information.
         items:
           format: uri
           minLength: 1
@@ -4416,17 +4321,15 @@ $defs:
           type: string
         - type: 'null'
         default:
-        description: A legal document under which the resource is made 
-          available.
+        description: A legal document under which the resource is made available.
         rdf_term: http://purl.org/dc/terms/license
         rdf_type: uri
         title: License
       language:
         default:
-        description: A language of the resource. This refers to the natural 
-          language used for textual metadata (i.e., titles, descriptions, etc.) 
-          of a cataloged resource (i.e., dataset or service) or the textual 
-          values of a dataset distribution
+        description: A language of the resource. This refers to the natural language
+          used for textual metadata (i.e., titles, descriptions, etc.) of a cataloged
+          resource (i.e., dataset or service) or the textual values of a dataset distribution
         items:
           format: uri
           minLength: 1
@@ -4437,8 +4340,8 @@ $defs:
         type: array
       relation:
         default:
-        description: A resource with an unspecified relationship to the 
-          cataloged resource.
+        description: A resource with an unspecified relationship to the cataloged
+          resource.
         items:
           format: uri
           minLength: 1
@@ -4454,17 +4357,15 @@ $defs:
           minLength: 1
           type: string
         default:
-        description: Information about rights held in and over the distribution.
-          Recommended practice is to refer to a rights statement with a URI. If 
-          this is not possible or feasible, a literal value (name, label, or 
-          short text) may be provided.
+        description: Information about rights held in and over the distribution. Recommended
+          practice is to refer to a rights statement with a URI. If this is not possible
+          or feasible, a literal value (name, label, or short text) may be provided.
         rdf_term: http://purl.org/dc/terms/rights
         rdf_type: uri
         title: Rights
       qualified_relation:
         default:
-        description: Link to a description of a relationship with another 
-          resource.
+        description: Link to a description of a relationship with another resource.
         items:
           anyOf:
           - format: uri
@@ -4493,14 +4394,13 @@ $defs:
         - format: date
           type: string
         default:
-        description: Date of formal issuance (e.g., publication) of the 
-          resource.
+        description: Date of formal issuance (e.g., publication) of the resource.
         rdf_term: http://purl.org/dc/terms/issued
         rdf_type: datetime_literal
         title: Release Date
       theme:
-        description: A main category of the resource. A resource can have 
-          multiple themes.
+        description: A main category of the resource. A resource can have multiple
+          themes.
         items:
           $ref: '#/$defs/DatasetTheme'
         rdf_term: http://www.w3.org/ns/dcat#theme
@@ -4536,8 +4436,8 @@ $defs:
         - format: date-time
           type: string
         default:
-        description: Most recent date on which the resource was changed, updated
-          or modified.
+        description: Most recent date on which the resource was changed, updated or
+          modified.
         rdf_term: http://purl.org/dc/terms/modified
         rdf_type: datetime_literal
         title: Modification Date
@@ -4556,8 +4456,8 @@ $defs:
         type: array
       has_current_version:
         default:
-        description: This resource has a more specific, versioned resource with 
-          equivalent content [PAV].
+        description: This resource has a more specific, versioned resource with equivalent
+          content [PAV].
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#hasCurrentVersion
@@ -4586,8 +4486,8 @@ $defs:
         type: string
       replaces:
         default:
-        description: A related resource that is supplanted, displaced, or 
-          superseded by the described resource
+        description: A related resource that is supplanted, displaced, or superseded
+          by the described resource
         format: uri
         minLength: 1
         rdf_term: http://purl.org/dc/terms/replaces
@@ -4597,8 +4497,8 @@ $defs:
       status:
         $ref: '#/$defs/DatasetStatus'
         default:
-        description: The status of the Asset in the context of a particular 
-          workflow process.
+        description: The status of the Asset in the context of a particular workflow
+          process.
         rdf_term: http://www.w3.org/ns/adms#status
         rdf_type: uri
       version:
@@ -4612,8 +4512,8 @@ $defs:
         title: Version
       version_notes:
         default:
-        description: A description of changes between this version and the 
-          previous version of the resource [VOCAB-ADMS].
+        description: A description of changes between this version and the previous
+          version of the resource [VOCAB-ADMS].
         items:
           anyOf:
           - type: string
@@ -4624,8 +4524,8 @@ $defs:
         type: array
       first:
         default:
-        description: The first resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The first resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#first
@@ -4634,8 +4534,8 @@ $defs:
         type: string
       last:
         default:
-        description: The last resource in an ordered collection or series of 
-          resources, to which the current resource belongs.
+        description: The last resource in an ordered collection or series of resources,
+          to which the current resource belongs.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/dcat#last
@@ -4644,8 +4544,8 @@ $defs:
         type: string
       previous:
         default:
-        description: The previous resource (before the current one) in an 
-          ordered collection or series of resources.
+        description: The previous resource (before the current one) in an ordered
+          collection or series of resources.
         items:
           format: uri
           minLength: 1
@@ -4713,8 +4613,8 @@ $defs:
         type: array
       spatial_resolution:
         default:
-        description: Minimum spatial separation resolvable in a dataset, 
-          measured in meters.
+        description: Minimum spatial separation resolvable in a dataset, measured
+          in meters.
         items:
           type: number
         rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
@@ -4732,8 +4632,8 @@ $defs:
         title: Temporal Resolution
       was_generated_by:
         default:
-        description: An activity that generated, or provides the business 
-          context for, the creation of the dataset.
+        description: An activity that generated, or provides the business context
+          for, the creation of the dataset.
         items:
           anyOf:
           - format: uri
@@ -4756,9 +4656,9 @@ $defs:
         type: array
       other_identifier:
         default:
-        description: Links a resource to an adms:Identifier class. Examples for 
-          secondary identifiers are MAST/ADS, DataCite, DOI, EZID or W3ID (if 
-          not used for the original identifier).
+        description: Links a resource to an adms:Identifier class. Examples for secondary
+          identifiers are MAST/ADS, DataCite, DOI, EZID or W3ID (if not used for the
+          original identifier).
         items:
           $ref: '#/$defs/Identifier'
         rdf_term: http://www.w3.org/ns/adms#identifier
@@ -4791,8 +4691,7 @@ $defs:
         type: array
       coding_system:
         default:
-        description: Health classifications and their codes associated with the 
-          dataset
+        description: Health classifications and their codes associated with the dataset
         items:
           format: uri
           minLength: 1
@@ -4829,8 +4728,8 @@ $defs:
           type: string
         - $ref: '#/$defs/HEALTHDCATAPHdab'
         default:
-        description: Health Data Access Body supporting access to data in the 
-          Member State.
+        description: Health Data Access Body supporting access to data in the Member
+          State.
         rdf_term: http://healthdataportal.eu/ns/health#hdab
         rdf_type: uri
         title: Hdab
@@ -4895,8 +4794,8 @@ $defs:
       retention_period:
         $ref: '#/$defs/PeriodOfTime'
         default:
-        description: A temporal period which the dataset is available for 
-          secondary use.
+        description: A temporal period which the dataset is available for secondary
+          use.
         rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
         rdf_type: http://purl.org/dc/terms/PeriodOfTime
       documentation:
@@ -4960,8 +4859,7 @@ $defs:
         type: array
       source:
         default:
-        description: A related resource from which the described resource is 
-          derived.
+        description: A related resource from which the described resource is derived.
         items:
           anyOf:
           - format: uri
@@ -4999,8 +4897,8 @@ $defs:
       Group)"
     properties:
       hasEmail:
-        description: To specify the electronic mail address for communication 
-          with the object.
+        description: To specify the electronic mail address for communication with
+          the object.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/vcard/ns#hasEmail
@@ -5026,8 +4924,8 @@ $defs:
         type: string
       contact_page:
         default:
-        description: A webpage that either allows to make contact (e.g. a 
-          webform) or provides information on how to get in touch.
+        description: A webpage that either allows to make contact (e.g. a webform)
+          or provides information on how to get in touch.
         items:
           format: uri
           minLength: 1
@@ -5052,8 +4950,8 @@ $defs:
         anyOf:
         - type: string
         - $ref: '#/$defs/LiteralField'
-        description: A string that is an identifier in the context of the 
-          identifier scheme referenced by its datatype.
+        description: A string that is an identifier in the context of the identifier
+          scheme referenced by its datatype.
         rdf_term: http://www.w3.org/2004/02/skos/core#notation
         rdf_type: rdfs_literal
         title: Notation
@@ -5075,7 +4973,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -5086,8 +4984,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -5119,8 +5016,7 @@ $defs:
         - locn
         - http://www.w3.org/ns/locn#
         default:
-        description: Associates a spatial thing [SDW-BP] with a corresponding 
-          geometry.
+        description: Associates a spatial thing [SDW-BP] with a corresponding geometry.
         rdf_term: http://www.w3.org/ns/locn#geometry
         rdf_type: geosparql:wktLiteral
         title: Geometry
@@ -5136,8 +5032,7 @@ $defs:
       centroid:
         $ref: '#/$defs/LiteralField'
         default:
-        description: The geographic center (centroid) of a spatial thing 
-          [SDW-BP].
+        description: The geographic center (centroid) of a spatial thing [SDW-BP].
         rdf_term: http://www.w3.org/ns/dcat#centroid
         rdf_type: geosparql:wktLiteral
     title: http://purl.org/dc/terms/Location
@@ -5191,8 +5086,8 @@ $defs:
         type: array
       inheritFrom:
         default:
-        description: Relates a (child) policy to another (parent) policy from 
-          which terms are inherited.
+        description: Relates a (child) policy to another (parent) policy from which
+          terms are inherited.
         items:
           format: uri
           minLength: 1
@@ -5203,8 +5098,8 @@ $defs:
         type: array
       profile:
         default:
-        description: The identifier(s) of an ODRL Profile that the Policy 
-          conforms to.
+        description: The identifier(s) of an ODRL Profile that the Policy conforms
+          to.
         items:
           format: uri
           minLength: 1
@@ -5237,8 +5132,8 @@ $defs:
         type: array
       relation:
         default:
-        description: Relation is an abstract property which creates an explicit 
-          link between an Action and an Asset.
+        description: Relation is an abstract property which creates an explicit link
+          between an Action and an Asset.
         items:
           format: uri
           minLength: 1
@@ -5249,8 +5144,8 @@ $defs:
         type: array
       target:
         default:
-        description: The target property indicates the Asset that is the primary
-          subject to which the Rule action directly applies.
+        description: The target property indicates the Asset that is the primary subject
+          to which the Rule action directly applies.
         items:
           format: uri
           minLength: 1
@@ -5261,9 +5156,9 @@ $defs:
         type: array
       function:
         default:
-        description: Function is an abstract property whose sub-properties 
-          define the functional roles which may be fulfilled by a party in 
-          relation to a Rule.
+        description: Function is an abstract property whose sub-properties define
+          the functional roles which may be fulfilled by a party in relation to a
+          Rule.
         items:
           format: uri
           minLength: 1
@@ -5274,8 +5169,8 @@ $defs:
         type: array
       action:
         default:
-        description: The operation relating to the Asset for which the Rule is 
-          being subjected.
+        description: The operation relating to the Asset for which the Rule is being
+          subjected.
         items:
           format: uri
           minLength: 1
@@ -5370,8 +5265,8 @@ $defs:
         type: string
       body:
         default:
-        description: The object of the relationship is a resource that is a body
-          of the Annotation.
+        description: The object of the relationship is a resource that is a body of
+          the Annotation.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/oa#hasBody
@@ -5382,8 +5277,7 @@ $defs:
     type: object
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -5395,8 +5289,8 @@ $defs:
     additionalProperties: false
     properties:
       had_role:
-        description: The function of an entity or agent with respect to another 
-          entity or resource.
+        description: The function of an entity or agent with respect to another entity
+          or resource.
         items:
           format: uri
           minLength: 1
@@ -5434,11 +5328,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -5447,9 +5340,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -5458,10 +5351,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -5470,9 +5362,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -5481,12 +5373,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -5494,11 +5385,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -5534,8 +5424,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -5543,8 +5432,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -5553,8 +5442,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -5571,15 +5459,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -5596,23 +5483,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -5646,8 +5533,8 @@ $defs:
         type: array
       formatted_name:
         default:
-        description: The full name of the object (as a single string). This is 
-          the only mandatory property.
+        description: The full name of the object (as a single string). This is the
+          only mandatory property.
         items:
           anyOf:
           - type: string
@@ -5716,8 +5603,7 @@ properties:
     - format: date-time
       type: string
     default:
-    description: Most recent date on which the resource was changed, updated or 
-      modified.
+    description: Most recent date on which the resource was changed, updated or modified.
     rdf_term: http://purl.org/dc/terms/modified
     rdf_type: datetime_literal
     title: Modification Date
@@ -5727,15 +5613,14 @@ properties:
       minLength: 1
       type: string
     - $ref: '#/$defs/GeonovumLicences'
-    description: A legal document giving official permission to do something 
-      with the resource.
+    description: A legal document giving official permission to do something with
+      the resource.
     rdf_term: http://purl.org/dc/terms/license
     rdf_type: uri
     title: License
   access_rights:
     default:
-    description: A data service that gives access to the distribution of the 
-      dataset.
+    description: A data service that gives access to the distribution of the dataset.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/accessRights
@@ -5753,13 +5638,13 @@ properties:
   has_policy:
     $ref: '#/$defs/ODRLPolicy'
     default:
-    description: An ODRL conformant policy expressing the rights associated with
-      the distribution.
+    description: An ODRL conformant policy expressing the rights associated with the
+      distribution.
     rdf_term: http://www.w3.org/ns/odrl/2/hasPolicy
     rdf_type: uri
   access_url:
-    description: A URL of the resource that gives access to a distribution of 
-      the dataset. E.g., landing page, feed, SPARQL endpoint.
+    description: A URL of the resource that gives access to a distribution of the
+      dataset. E.g., landing page, feed, SPARQL endpoint.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#accessURL
@@ -5773,16 +5658,15 @@ properties:
       type: string
     - $ref: '#/$defs/HRIDataService'
     default:
-    description: A data service that gives access to the distribution of the 
-      dataset.
+    description: A data service that gives access to the distribution of the dataset.
     rdf_term: http://www.w3.org/ns/dcat#accessService
     rdf_type: uri
     title: Access Service
   download_url:
     default:
-    description: The URL of the downloadable file in a given format. E.g., CSV 
-      file or RDF file. The format is indicated by the distribution's 
-      dcterms:format and/or dcat:mediaType.
+    description: The URL of the downloadable file in a given format. E.g., CSV file
+      or RDF file. The format is indicated by the distribution's dcterms:format and/or
+      dcat:mediaType.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#downloadURL
@@ -5802,8 +5686,8 @@ properties:
     - type: number
     - $ref: '#/$defs/LiteralField'
     default:
-    description: Minimum spatial separation resolvable in a dataset 
-      distribution, measured in meters.
+    description: Minimum spatial separation resolvable in a dataset distribution,
+      measured in meters.
     rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
     rdf_type: xsd:decimal
     title: Spatial Resolution
@@ -5813,7 +5697,7 @@ properties:
     - $ref: '#/$defs/LiteralField'
     default:
     description: Minimum time period resolvable in the dataset.
-    rdf_term: http://www.w3.org/ns/dcat#spatialResolutionInMeters
+    rdf_term: http://www.w3.org/ns/dcat#temporalResolution
     rdf_type: xsd:duration
     title: Temporal Resolution
   conforms_to:
@@ -5837,8 +5721,7 @@ properties:
     title: Media Type
     type: string
   format:
-    description: The file format, physical medium, or dimensions of the 
-      resource.
+    description: The file format, physical medium, or dimensions of the resource.
     format: uri
     minLength: 1
     rdf_term: http://purl.org/dc/terms/format
@@ -5847,9 +5730,8 @@ properties:
     type: string
   compression_format:
     default:
-    description: The compression format of the distribution in which the data is
-      contained in a compressed form, e.g., to reduce the size of the 
-      downloadable file.
+    description: The compression format of the distribution in which the data is contained
+      in a compressed form, e.g., to reduce the size of the downloadable file.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#compressFormat
@@ -5858,9 +5740,9 @@ properties:
     type: string
   packaging_format:
     default:
-    description: The package format of the distribution in which one or more 
-      data files are grouped together, e.g., to enable a set of related files to
-      be downloaded together.
+    description: The package format of the distribution in which one or more data
+      files are grouped together, e.g., to enable a set of related files to be downloaded
+      together.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/dcat#packageFormat
@@ -5870,8 +5752,8 @@ properties:
   checksum:
     $ref: '#/$defs/Checksum'
     default:
-    description: The checksum property provides a mechanism that can be used to 
-      verify that the contents of a file or package have not changed [SPDX].
+    description: The checksum property provides a mechanism that can be used to verify
+      that the contents of a file or package have not changed [SPDX].
     rdf_term: http://spdx.org/rdf/terms#checksum
     rdf_type: uri
   retention_period:
@@ -5881,8 +5763,7 @@ properties:
       type: string
     - $ref: '#/$defs/PeriodOfTime'
     default:
-    description: A temporal period which the dataset is available for secondary 
-      use.
+    description: A temporal period which the dataset is available for secondary use.
     rdf_term: http://healthdataportal.eu/ns/health#retentionPeriod
     rdf_type: uri
     title: Retention Period
@@ -5921,8 +5802,7 @@ properties:
     type: array
   linked_schemas:
     default:
-    description: An established standard to which the described resource 
-      conforms.
+    description: An established standard to which the described resource conforms.
     items:
       format: uri
       minLength: 1
@@ -5938,8 +5818,8 @@ properties:
       type: string
     - $ref: '#/$defs/DistributionStatus'
     default:
-    description: The status of the distribution (e.g., under development, 
-      completed, deprecated, withdrawn).
+    description: The status of the distribution (e.g., under development, completed,
+      deprecated, withdrawn).
     rdf_term: http://www.w3.org/ns/adms#status
     rdf_type: uri
     title: Status

--- a/models/hri_dcat/HRIVCard.yaml
+++ b/models/hri_dcat/HRIVCard.yaml
@@ -5,7 +5,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -16,8 +16,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -43,8 +42,8 @@ description: "The vCard class is equivalent to the new Kind class, which is the 
   for the four explicit types\nof vCards (Individual, Organization, Location, Group)"
 properties:
   hasEmail:
-    description: To specify the electronic mail address for communication with 
-      the object.
+    description: To specify the electronic mail address for communication with the
+      object.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/2006/vcard/ns#hasEmail
@@ -70,8 +69,8 @@ properties:
     type: string
   contact_page:
     default:
-    description: A webpage that either allows to make contact (e.g. a webform) 
-      or provides information on how to get in touch.
+    description: A webpage that either allows to make contact (e.g. a webform) or
+      provides information on how to get in touch.
     items:
       format: uri
       minLength: 1

--- a/models/odrl/ODRLPolicy.yaml
+++ b/models/odrl/ODRLPolicy.yaml
@@ -2,8 +2,7 @@ $IRI: http://www.w3.org/ns/odrl/2/Policy
 $defs:
   RDFModel:
     additionalProperties: false
-    description: Base class for creating pydantic models convertible to RDF 
-      graph
+    description: Base class for creating pydantic models convertible to RDF graph
     properties: {}
     title: RDFModel
     type: object
@@ -54,8 +53,8 @@ properties:
     type: array
   inheritFrom:
     default:
-    description: Relates a (child) policy to another (parent) policy from which 
-      terms are inherited.
+    description: Relates a (child) policy to another (parent) policy from which terms
+      are inherited.
     items:
       format: uri
       minLength: 1
@@ -66,8 +65,7 @@ properties:
     type: array
   profile:
     default:
-    description: The identifier(s) of an ODRL Profile that the Policy conforms 
-      to.
+    description: The identifier(s) of an ODRL Profile that the Policy conforms to.
     items:
       format: uri
       minLength: 1
@@ -100,8 +98,8 @@ properties:
     type: array
   relation:
     default:
-    description: Relation is an abstract property which creates an explicit link
-      between an Action and an Asset.
+    description: Relation is an abstract property which creates an explicit link between
+      an Action and an Asset.
     items:
       format: uri
       minLength: 1
@@ -112,8 +110,8 @@ properties:
     type: array
   target:
     default:
-    description: The target property indicates the Asset that is the primary 
-      subject to which the Rule action directly applies.
+    description: The target property indicates the Asset that is the primary subject
+      to which the Rule action directly applies.
     items:
       format: uri
       minLength: 1
@@ -124,9 +122,8 @@ properties:
     type: array
   function:
     default:
-    description: Function is an abstract property whose sub-properties define 
-      the functional roles which may be fulfilled by a party in relation to a 
-      Rule.
+    description: Function is an abstract property whose sub-properties define the
+      functional roles which may be fulfilled by a party in relation to a Rule.
     items:
       format: uri
       minLength: 1
@@ -137,8 +134,7 @@ properties:
     type: array
   action:
     default:
-    description: The operation relating to the Asset for which the Rule is being
-      subjected.
+    description: The operation relating to the Asset for which the Rule is being subjected.
     items:
       format: uri
       minLength: 1

--- a/models/prov/Activity.yaml
+++ b/models/prov/Activity.yaml
@@ -13,8 +13,8 @@ $defs:
     properties:
       hadPlan:
         default:
-        description: A plan is an entity that represents a set of actions or 
-          steps intended by one or more agents to achieve some goals.
+        description: A plan is an entity that represents a set of actions or steps
+          intended by one or more agents to achieve some goals.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -23,9 +23,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -34,11 +34,10 @@ $defs:
         type: string
       agent:
         default:
-        description: The prov:agent property references an prov:Agent which 
-          influenced a resource. This property applies to an 
-          prov:AgentInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:agent property references an prov:Agent which influenced
+          a resource. This property applies to an prov:AgentInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Agent
@@ -61,11 +60,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -74,9 +72,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -85,10 +83,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -97,9 +94,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -108,12 +105,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -121,11 +117,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -148,11 +143,10 @@ $defs:
     properties:
       entity:
         default:
-        description: The prov:entity property references an prov:Entity which 
-          influenced a resource. This property applies to an 
-          prov:EntityInfluence, which is given by a subproperty of 
-          prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity
-          or prov:Agent.
+        description: The prov:entity property references an prov:Entity which influenced
+          a resource. This property applies to an prov:EntityInfluence, which is given
+          by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+          prov:Activity or prov:Agent.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#Entity
@@ -161,9 +155,9 @@ $defs:
         type: string
       hadRole:
         default:
-        description: A role is the function of an entity or agent with respect 
-          to an activity, in the context of a usage, generation, invalidation, 
-          association, start, and end.
+        description: A role is the function of an entity or agent with respect to
+          an activity, in the context of a usage, generation, invalidation, association,
+          start, and end.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -172,10 +166,9 @@ $defs:
         type: string
       influencer:
         default:
-        description: This property is used as part of the qualified influence 
-          pattern. Subclasses of prov:Influence use these subproperties to 
-          reference the resource (Entity, Agent, or Activity) whose influence is
-          being qualified.
+        description: This property is used as part of the qualified influence pattern.
+          Subclasses of prov:Influence use these subproperties to reference the resource
+          (Entity, Agent, or Activity) whose influence is being qualified.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#influencer
@@ -184,9 +177,9 @@ $defs:
         type: string
       hadActivity:
         default:
-        description: An activity is something that occurs over a period of time 
-          and acts upon or with entities; it may include consuming, processing, 
-          transforming, modifying, relocating, using, or generating entities.
+        description: An activity is something that occurs over a period of time and
+          acts upon or with entities; it may include consuming, processing, transforming,
+          modifying, relocating, using, or generating entities.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -195,12 +188,11 @@ $defs:
         type: string
       atTime:
         default:
-        description: The PROV data model is implicitly based on a notion of 
-          instantaneous events (or just events), that mark transitions in the 
-          world. Events include generation, usage, or invalidation of entities, 
-          as well as starting or ending of activities. This notion of event is 
-          not first-class in the data model, but it is useful for explaining its
-          other concepts and its semantics.
+        description: The PROV data model is implicitly based on a notion of instantaneous
+          events (or just events), that mark transitions in the world. Events include
+          generation, usage, or invalidation of entities, as well as starting or ending
+          of activities. This notion of event is not first-class in the data model,
+          but it is useful for explaining its other concepts and its semantics.
         format: date-time
         rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
         rdf_type: xsd:dateTime
@@ -208,11 +200,10 @@ $defs:
         type: string
       atLocation:
         default:
-        description: A location can be an identifiable geographic place (ISO 
-          19112), but it can also be a non-geographic place such as a directory,
-          row, or column. As such, there are numerous ways in which location can
-          be expressed, such as by a coordinate, address, landmark, and so 
-          forth.
+        description: A location can be an identifiable geographic place (ISO 19112),
+          but it can also be a non-geographic place such as a directory, row, or column.
+          As such, there are numerous ways in which location can be expressed, such
+          as by a coordinate, address, landmark, and so forth.
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/ns/prov#atLocation
@@ -231,9 +222,9 @@ description: "An activity is something that occurs over a period of time and act
 properties:
   generated:
     default:
-    description: Generation is the completion of production of a new entity by 
-      an activity. This entity did not exist before generation and becomes 
-      available for usage after this generation.
+    description: Generation is the completion of production of a new entity by an
+      activity. This entity did not exist before generation and becomes available
+      for usage after this generation.
     items:
       format: uri
       minLength: 1
@@ -244,11 +235,10 @@ properties:
     type: array
   qualifiedAssociation:
     default:
-    description: An activity association is an assignment of responsibility to 
-      an agent for an activity, indicating that the agent had a role in the 
-      activity. It further allows for a plan to be specified, which is the plan 
-      intended by the agent to achieve some goals in the context of this 
-      activity.
+    description: An activity association is an assignment of responsibility to an
+      agent for an activity, indicating that the agent had a role in the activity.
+      It further allows for a plan to be specified, which is the plan intended by
+      the agent to achieve some goals in the context of this activity.
     items:
       anyOf:
       - format: uri
@@ -261,11 +251,10 @@ properties:
     type: array
   wasAssociatedWith:
     default:
-    description: An activity association is an assignment of responsibility to 
-      an agent for an activity, indicating that the agent had a role in the 
-      activity. It further allows for a plan to be specified, which is the plan 
-      intended by the agent to achieve some goals in the context of this 
-      activity.
+    description: An activity association is an assignment of responsibility to an
+      agent for an activity, indicating that the agent had a role in the activity.
+      It further allows for a plan to be specified, which is the plan intended by
+      the agent to achieve some goals in the context of this activity.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#wasAssociatedWith
@@ -275,20 +264,20 @@ properties:
   qualifiedEnd:
     $ref: '#/$defs/End'
     default:
-    description: End is when an activity is deemed to have been ended by an 
-      entity, known as trigger. The activity no longer exists after its end. Any
-      usage, generation, or invalidation involving an activity precedes the 
-      activity's end. An end may refer to a trigger entity that terminated the 
-      activity, or to an activity, known as ender that generated the trigger.
+    description: End is when an activity is deemed to have been ended by an entity,
+      known as trigger. The activity no longer exists after its end. Any usage, generation,
+      or invalidation involving an activity precedes the activity's end. An end may
+      refer to a trigger entity that terminated the activity, or to an activity, known
+      as ender that generated the trigger.
     rdf_term: http://www.w3.org/ns/prov#qualifiedEnd
     rdf_type: http://www.w3.org/ns/prov#End
   wasEndedBy:
     default:
-    description: End is when an activity is deemed to have been ended by an 
-      entity, known as trigger. The activity no longer exists after its end. Any
-      usage, generation, or invalidation involving an activity precedes the 
-      activity's end. An end may refer to a trigger entity that terminated the 
-      activity, or to an activity, known as ender that generated the trigger.
+    description: End is when an activity is deemed to have been ended by an entity,
+      known as trigger. The activity no longer exists after its end. Any usage, generation,
+      or invalidation involving an activity precedes the activity's end. An end may
+      refer to a trigger entity that terminated the activity, or to an activity, known
+      as ender that generated the trigger.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#wasEndedBy
@@ -297,9 +286,9 @@ properties:
     type: string
   qualifiedUsage:
     default:
-    description: Usage is the beginning of utilizing an entity by an activity. 
-      Before usage, the activity had not begun to utilize this entity and could 
-      not have been affected by the entity.
+    description: Usage is the beginning of utilizing an entity by an activity. Before
+      usage, the activity had not begun to utilize this entity and could not have
+      been affected by the entity.
     items:
       format: uri
       minLength: 1
@@ -310,9 +299,9 @@ properties:
     type: array
   used:
     default:
-    description: Usage is the beginning of utilizing an entity by an activity. 
-      Before usage, the activity had not begun to utilize this entity and could 
-      not have been affected by the entity.
+    description: Usage is the beginning of utilizing an entity by an activity. Before
+      usage, the activity had not begun to utilize this entity and could not have
+      been affected by the entity.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#used
@@ -321,10 +310,10 @@ properties:
     type: string
   invalidated:
     default:
-    description: Invalidation is the start of the destruction, cessation, or 
-      expiry of an existing entity by an activity. The entity is no longer 
-      available for use (or further invalidation) after invalidation. Any 
-      generation or usage of an entity precedes its invalidation.
+    description: Invalidation is the start of the destruction, cessation, or expiry
+      of an existing entity by an activity. The entity is no longer available for
+      use (or further invalidation) after invalidation. Any generation or usage of
+      an entity precedes its invalidation.
     items:
       format: uri
       minLength: 1
@@ -335,11 +324,11 @@ properties:
     type: array
   endedAtTime:
     default:
-    description: End is when an activity is deemed to have been ended by an 
-      entity, known as trigger. The activity no longer exists after its end. Any
-      usage, generation, or invalidation involving an activity precedes the 
-      activity's end. An end may refer to a trigger entity that terminated the 
-      activity, or to an activity, known as ender that generated the trigger.
+    description: End is when an activity is deemed to have been ended by an entity,
+      known as trigger. The activity no longer exists after its end. Any usage, generation,
+      or invalidation involving an activity precedes the activity's end. An end may
+      refer to a trigger entity that terminated the activity, or to an activity, known
+      as ender that generated the trigger.
     format: date-time
     rdf_term: http://www.w3.org/ns/prov#endedAtTime
     rdf_type: xsd:dateTime
@@ -348,17 +337,17 @@ properties:
   qualifiedStart:
     $ref: '#/$defs/Start'
     default:
-    description: Start is when an activity is deemed to have been started by an 
-      entity, known as trigger. The activity did not exist before its start. Any
-      usage, generation, or invalidation involving an activity follows the 
-      activity's start. A start may refer to a trigger entity that set off the 
-      activity, or to an activity, known as starter, that generated the trigger.
+    description: Start is when an activity is deemed to have been started by an entity,
+      known as trigger. The activity did not exist before its start. Any usage, generation,
+      or invalidation involving an activity follows the activity's start. A start
+      may refer to a trigger entity that set off the activity, or to an activity,
+      known as starter, that generated the trigger.
     rdf_term: http://www.w3.org/ns/prov#qualifiedStart
     rdf_type: http://www.w3.org/ns/prov#Start
   wasInformedBy:
     default:
-    description: Communication is the exchange of an entity by two activities, 
-      one activity using the entity generated by the other.
+    description: Communication is the exchange of an entity by two activities, one
+      activity using the entity generated by the other.
     items:
       format: uri
       minLength: 1
@@ -369,11 +358,11 @@ properties:
     type: array
   wasStartedBy:
     default:
-    description: Start is when an activity is deemed to have been started by an 
-      entity, known as trigger. The activity did not exist before its start. Any
-      usage, generation, or invalidation involving an activity follows the 
-      activity's start. A start may refer to a trigger entity that set off the 
-      activity, or to an activity, known as starter, that generated the trigger.
+    description: Start is when an activity is deemed to have been started by an entity,
+      known as trigger. The activity did not exist before its start. Any usage, generation,
+      or invalidation involving an activity follows the activity's start. A start
+      may refer to a trigger entity that set off the activity, or to an activity,
+      known as starter, that generated the trigger.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#wasStartedBy
@@ -382,11 +371,11 @@ properties:
     type: string
   startedAtTime:
     default:
-    description: Start is when an activity is deemed to have been started by an 
-      entity, known as trigger. The activity did not exist before its start. Any
-      usage, generation, or invalidation involving an activity follows the 
-      activity's start. A start may refer to a trigger entity that set off the 
-      activity, or to an activity, known as starter, that generated the trigger.
+    description: Start is when an activity is deemed to have been started by an entity,
+      known as trigger. The activity did not exist before its start. Any usage, generation,
+      or invalidation involving an activity follows the activity's start. A start
+      may refer to a trigger entity that set off the activity, or to an activity,
+      known as starter, that generated the trigger.
     format: date-time
     rdf_term: http://www.w3.org/ns/prov#startedAtTime
     rdf_type: xsd:dateTime
@@ -394,8 +383,8 @@ properties:
     type: string
   qualifiedCommunication:
     default:
-    description: Communication is the exchange of an entity by two activities, 
-      one activity using the entity generated by the other.
+    description: Communication is the exchange of an entity by two activities, one
+      activity using the entity generated by the other.
     items:
       format: uri
       minLength: 1
@@ -406,10 +395,10 @@ properties:
     type: array
   wasInfluencedBy:
     default:
-    description: Influence is the capacity of an entity, activity, or agent to 
-      have an effect on the character, development, or behavior of another by 
-      means of usage, start, end, generation, invalidation, communication, 
-      derivation, attribution, association, or delegation.
+    description: Influence is the capacity of an entity, activity, or agent to have
+      an effect on the character, development, or behavior of another by means of
+      usage, start, end, generation, invalidation, communication, derivation, attribution,
+      association, or delegation.
     items:
       format: uri
       minLength: 1
@@ -420,10 +409,10 @@ properties:
     type: array
   qualifiedInfluence:
     default:
-    description: Influence is the capacity of an entity, activity, or agent to 
-      have an effect on the character, development, or behavior of another by 
-      means of usage, start, end, generation, invalidation, communication, 
-      derivation, attribution, association, or delegation.
+    description: Influence is the capacity of an entity, activity, or agent to have
+      an effect on the character, development, or behavior of another by means of
+      usage, start, end, generation, invalidation, communication, derivation, attribution,
+      association, or delegation.
     items:
       format: uri
       minLength: 1
@@ -434,10 +423,10 @@ properties:
     type: array
   atLocation:
     default:
-    description: A location can be an identifiable geographic place (ISO 19112),
-      but it can also be a non-geographic place such as a directory, row, or 
-      column. As such, there are numerous ways in which location can be 
-      expressed, such as by a coordinate, address, landmark, and so forth.
+    description: A location can be an identifiable geographic place (ISO 19112), but
+      it can also be a non-geographic place such as a directory, row, or column. As
+      such, there are numerous ways in which location can be expressed, such as by
+      a coordinate, address, landmark, and so forth.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#atLocation

--- a/models/prov/Association.yaml
+++ b/models/prov/Association.yaml
@@ -10,8 +10,8 @@ description: "An activity association is an assignment of responsibility to an a
 properties:
   hadPlan:
     default:
-    description: A plan is an entity that represents a set of actions or steps 
-      intended by one or more agents to achieve some goals.
+    description: A plan is an entity that represents a set of actions or steps intended
+      by one or more agents to achieve some goals.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadPlan
@@ -20,9 +20,9 @@ properties:
     type: string
   hadRole:
     default:
-    description: A role is the function of an entity or agent with respect to an
-      activity, in the context of a usage, generation, invalidation, 
-      association, start, and end.
+    description: A role is the function of an entity or agent with respect to an activity,
+      in the context of a usage, generation, invalidation, association, start, and
+      end.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -31,10 +31,10 @@ properties:
     type: string
   agent:
     default:
-    description: The prov:agent property references an prov:Agent which 
-      influenced a resource. This property applies to an prov:AgentInfluence, 
-      which is given by a subproperty of prov:qualifiedInfluence from the 
-      influenced prov:Entity, prov:Activity or prov:Agent.
+    description: The prov:agent property references an prov:Agent which influenced
+      a resource. This property applies to an prov:AgentInfluence, which is given
+      by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+      prov:Activity or prov:Agent.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#Agent

--- a/models/prov/End.yaml
+++ b/models/prov/End.yaml
@@ -11,10 +11,10 @@ description: "End is when an activity is deemed to have been ended by an entity,
 properties:
   entity:
     default:
-    description: The prov:entity property references an prov:Entity which 
-      influenced a resource. This property applies to an prov:EntityInfluence, 
-      which is given by a subproperty of prov:qualifiedInfluence from the 
-      influenced prov:Entity, prov:Activity or prov:Agent.
+    description: The prov:entity property references an prov:Entity which influenced
+      a resource. This property applies to an prov:EntityInfluence, which is given
+      by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+      prov:Activity or prov:Agent.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#Entity
@@ -23,9 +23,9 @@ properties:
     type: string
   hadRole:
     default:
-    description: A role is the function of an entity or agent with respect to an
-      activity, in the context of a usage, generation, invalidation, 
-      association, start, and end.
+    description: A role is the function of an entity or agent with respect to an activity,
+      in the context of a usage, generation, invalidation, association, start, and
+      end.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -34,10 +34,9 @@ properties:
     type: string
   influencer:
     default:
-    description: This property is used as part of the qualified influence 
-      pattern. Subclasses of prov:Influence use these subproperties to reference
-      the resource (Entity, Agent, or Activity) whose influence is being 
-      qualified.
+    description: This property is used as part of the qualified influence pattern.
+      Subclasses of prov:Influence use these subproperties to reference the resource
+      (Entity, Agent, or Activity) whose influence is being qualified.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#influencer
@@ -46,9 +45,9 @@ properties:
     type: string
   hadActivity:
     default:
-    description: An activity is something that occurs over a period of time and 
-      acts upon or with entities; it may include consuming, processing, 
-      transforming, modifying, relocating, using, or generating entities.
+    description: An activity is something that occurs over a period of time and acts
+      upon or with entities; it may include consuming, processing, transforming, modifying,
+      relocating, using, or generating entities.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -57,12 +56,11 @@ properties:
     type: string
   atTime:
     default:
-    description: The PROV data model is implicitly based on a notion of 
-      instantaneous events (or just events), that mark transitions in the world.
-      Events include generation, usage, or invalidation of entities, as well as 
-      starting or ending of activities. This notion of event is not first-class 
-      in the data model, but it is useful for explaining its other concepts and 
-      its semantics.
+    description: The PROV data model is implicitly based on a notion of instantaneous
+      events (or just events), that mark transitions in the world. Events include
+      generation, usage, or invalidation of entities, as well as starting or ending
+      of activities. This notion of event is not first-class in the data model, but
+      it is useful for explaining its other concepts and its semantics.
     format: date-time
     rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
     rdf_type: xsd:dateTime
@@ -70,10 +68,10 @@ properties:
     type: string
   atLocation:
     default:
-    description: A location can be an identifiable geographic place (ISO 19112),
-      but it can also be a non-geographic place such as a directory, row, or 
-      column. As such, there are numerous ways in which location can be 
-      expressed, such as by a coordinate, address, landmark, and so forth.
+    description: A location can be an identifiable geographic place (ISO 19112), but
+      it can also be a non-geographic place such as a directory, row, or column. As
+      such, there are numerous ways in which location can be expressed, such as by
+      a coordinate, address, landmark, and so forth.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#atLocation

--- a/models/prov/EntityInfluence.yaml
+++ b/models/prov/EntityInfluence.yaml
@@ -9,10 +9,10 @@ description: "EntityInfluence is the capacity of an entity to have an effect on 
 properties:
   entity:
     default:
-    description: The prov:entity property references an prov:Entity which 
-      influenced a resource. This property applies to an prov:EntityInfluence, 
-      which is given by a subproperty of prov:qualifiedInfluence from the 
-      influenced prov:Entity, prov:Activity or prov:Agent.
+    description: The prov:entity property references an prov:Entity which influenced
+      a resource. This property applies to an prov:EntityInfluence, which is given
+      by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+      prov:Activity or prov:Agent.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#Entity
@@ -21,9 +21,9 @@ properties:
     type: string
   hadRole:
     default:
-    description: A role is the function of an entity or agent with respect to an
-      activity, in the context of a usage, generation, invalidation, 
-      association, start, and end.
+    description: A role is the function of an entity or agent with respect to an activity,
+      in the context of a usage, generation, invalidation, association, start, and
+      end.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -32,10 +32,9 @@ properties:
     type: string
   influencer:
     default:
-    description: This property is used as part of the qualified influence 
-      pattern. Subclasses of prov:Influence use these subproperties to reference
-      the resource (Entity, Agent, or Activity) whose influence is being 
-      qualified.
+    description: This property is used as part of the qualified influence pattern.
+      Subclasses of prov:Influence use these subproperties to reference the resource
+      (Entity, Agent, or Activity) whose influence is being qualified.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#influencer
@@ -44,9 +43,9 @@ properties:
     type: string
   hadActivity:
     default:
-    description: An activity is something that occurs over a period of time and 
-      acts upon or with entities; it may include consuming, processing, 
-      transforming, modifying, relocating, using, or generating entities.
+    description: An activity is something that occurs over a period of time and acts
+      upon or with entities; it may include consuming, processing, transforming, modifying,
+      relocating, using, or generating entities.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadActivity

--- a/models/prov/InstantaneousEvent.yaml
+++ b/models/prov/InstantaneousEvent.yaml
@@ -11,12 +11,11 @@ description: "The PROV data model is implicitly based on a notion of instantaneo
 properties:
   atTime:
     default:
-    description: The PROV data model is implicitly based on a notion of 
-      instantaneous events (or just events), that mark transitions in the world.
-      Events include generation, usage, or invalidation of entities, as well as 
-      starting or ending of activities. This notion of event is not first-class 
-      in the data model, but it is useful for explaining its other concepts and 
-      its semantics.
+    description: The PROV data model is implicitly based on a notion of instantaneous
+      events (or just events), that mark transitions in the world. Events include
+      generation, usage, or invalidation of entities, as well as starting or ending
+      of activities. This notion of event is not first-class in the data model, but
+      it is useful for explaining its other concepts and its semantics.
     format: date-time
     rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
     rdf_type: xsd:dateTime
@@ -24,9 +23,9 @@ properties:
     type: string
   hadRole:
     default:
-    description: A role is the function of an entity or agent with respect to an
-      activity, in the context of a usage, generation, invalidation, 
-      association, start, and end.
+    description: A role is the function of an entity or agent with respect to an activity,
+      in the context of a usage, generation, invalidation, association, start, and
+      end.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -35,10 +34,10 @@ properties:
     type: string
   atLocation:
     default:
-    description: A location can be an identifiable geographic place (ISO 19112),
-      but it can also be a non-geographic place such as a directory, row, or 
-      column. As such, there are numerous ways in which location can be 
-      expressed, such as by a coordinate, address, landmark, and so forth.
+    description: A location can be an identifiable geographic place (ISO 19112), but
+      it can also be a non-geographic place such as a directory, row, or column. As
+      such, there are numerous ways in which location can be expressed, such as by
+      a coordinate, address, landmark, and so forth.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#atLocation

--- a/models/prov/Start.yaml
+++ b/models/prov/Start.yaml
@@ -6,15 +6,15 @@ additionalProperties: false
 description: "Start is when an activity is deemed to have been started by an entity,
   known as trigger. The activity did\nnot exist before its start. Any usage, generation,
   or invalidation involving an activity follows the\nactivity's start. A start may
-  refer to a trigger entity that set off the activity, or to an activity, known as\n\
+  refer to a trigger entity that set off the activity, or to an activity, known as\n
   starter, that generated the trigger."
 properties:
   entity:
     default:
-    description: The prov:entity property references an prov:Entity which 
-      influenced a resource. This property applies to an prov:EntityInfluence, 
-      which is given by a subproperty of prov:qualifiedInfluence from the 
-      influenced prov:Entity, prov:Activity or prov:Agent.
+    description: The prov:entity property references an prov:Entity which influenced
+      a resource. This property applies to an prov:EntityInfluence, which is given
+      by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity,
+      prov:Activity or prov:Agent.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#Entity
@@ -23,9 +23,9 @@ properties:
     type: string
   hadRole:
     default:
-    description: A role is the function of an entity or agent with respect to an
-      activity, in the context of a usage, generation, invalidation, 
-      association, start, and end.
+    description: A role is the function of an entity or agent with respect to an activity,
+      in the context of a usage, generation, invalidation, association, start, and
+      end.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadRole
@@ -34,10 +34,9 @@ properties:
     type: string
   influencer:
     default:
-    description: This property is used as part of the qualified influence 
-      pattern. Subclasses of prov:Influence use these subproperties to reference
-      the resource (Entity, Agent, or Activity) whose influence is being 
-      qualified.
+    description: This property is used as part of the qualified influence pattern.
+      Subclasses of prov:Influence use these subproperties to reference the resource
+      (Entity, Agent, or Activity) whose influence is being qualified.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#influencer
@@ -46,9 +45,9 @@ properties:
     type: string
   hadActivity:
     default:
-    description: An activity is something that occurs over a period of time and 
-      acts upon or with entities; it may include consuming, processing, 
-      transforming, modifying, relocating, using, or generating entities.
+    description: An activity is something that occurs over a period of time and acts
+      upon or with entities; it may include consuming, processing, transforming, modifying,
+      relocating, using, or generating entities.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#hadActivity
@@ -57,12 +56,11 @@ properties:
     type: string
   atTime:
     default:
-    description: The PROV data model is implicitly based on a notion of 
-      instantaneous events (or just events), that mark transitions in the world.
-      Events include generation, usage, or invalidation of entities, as well as 
-      starting or ending of activities. This notion of event is not first-class 
-      in the data model, but it is useful for explaining its other concepts and 
-      its semantics.
+    description: The PROV data model is implicitly based on a notion of instantaneous
+      events (or just events), that mark transitions in the world. Events include
+      generation, usage, or invalidation of entities, as well as starting or ending
+      of activities. This notion of event is not first-class in the data model, but
+      it is useful for explaining its other concepts and its semantics.
     format: date-time
     rdf_term: http://www.w3.org/ns/prov#InstantaneousEvent
     rdf_type: xsd:dateTime
@@ -70,10 +68,10 @@ properties:
     type: string
   atLocation:
     default:
-    description: A location can be an identifiable geographic place (ISO 19112),
-      but it can also be a non-geographic place such as a directory, row, or 
-      column. As such, there are numerous ways in which location can be 
-      expressed, such as by a coordinate, address, landmark, and so forth.
+    description: A location can be an identifiable geographic place (ISO 19112), but
+      it can also be a non-geographic place such as a directory, row, or column. As
+      such, there are numerous ways in which location can be expressed, such as by
+      a coordinate, address, landmark, and so forth.
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/ns/prov#atLocation

--- a/models/spdx/Checksum.yaml
+++ b/models/spdx/Checksum.yaml
@@ -5,7 +5,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -16,8 +16,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -37,8 +36,8 @@ $namespace: http://spdx.org/rdf/terms#
 $ontology: http://spdx.org/rdf/terms/2.3
 $prefix: spdx
 additionalProperties: false
-description: "A Checksum is value that allows the contents of a file to be authenticated.\
-  \ \nEven small changes to the content of the file will change its checksum. \nThis
+description: "A Checksum is value that allows the contents of a file to be authenticated.
+  \nEven small changes to the content of the file will change its checksum. \nThis
   class allows the results of a variety of checksum and cryptographic message digest
   algorithms to be \nrepresented."
 properties:
@@ -54,8 +53,8 @@ properties:
     anyOf:
     - type: string
     - $ref: '#/$defs/LiteralField'
-    description: A lower case hexadecimal encoded digest value produced using a 
-      specific algorithm.
+    description: A lower case hexadecimal encoded digest value produced using a specific
+      algorithm.
     rdf_term: http://spdx.org/rdf/terms#checksumValue
     rdf_type: xsd:hexBinary
     title: Checksum Value

--- a/models/time/DateTimeDescription.yaml
+++ b/models/time/DateTimeDescription.yaml
@@ -46,8 +46,8 @@ properties:
     title: Timezone
     type: string
   unitType:
-    description: The temporal unit which provides the precision of a date-time 
-      value or scale of a temporal extent
+    description: The temporal unit which provides the precision of a date-time value
+      or scale of a temporal extent
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/2006/time#unitType
@@ -57,28 +57,27 @@ properties:
   hasTRS:
     const: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
     default: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
-    description: The temporal reference system used by a temporal position or 
-      extent description
+    description: The temporal reference system used by a temporal position or extent
+      description
     rdf_term: http://www.w3.org/2006/time#hasTRS
     rdf_type: uri
     title: Hastrs
     type: string
   year:
     default:
-    description: Year position in a calendar-clock system. The range of this 
-      property is not specified, so can be replaced by any specific 
-      representation of a calendar year from any calendar.
-    pattern: 
-      -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+    description: Year position in a calendar-clock system. The range of this property
+      is not specified, so can be replaced by any specific representation of a calendar
+      year from any calendar.
+    pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
     rdf_term: http://www.w3.org/2006/time#year
     rdf_type: xsd:gYear
     title: Year
     type: string
   month:
     default:
-    description: Month position in a calendar-clock system. The range of this 
-      property is not specified, so can be replaced by any specific 
-      representation of a calendar month from any calendar.
+    description: Month position in a calendar-clock system. The range of this property
+      is not specified, so can be replaced by any specific representation of a calendar
+      month from any calendar.
     pattern: --(0[1-9]|1[0-2])(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
     rdf_term: http://www.w3.org/2006/time#month
     rdf_type: xsd:gMonth
@@ -86,9 +85,9 @@ properties:
     type: string
   day:
     default:
-    description: Day position in a calendar-clock system. The range of this 
-      property is not specified, so can be replaced by any specific 
-      representation of a calendar day from any calendar.
+    description: Day position in a calendar-clock system. The range of this property
+      is not specified, so can be replaced by any specific representation of a calendar
+      day from any calendar.
     pattern: '---(0[1-9]|[12][0-9]|3[01])(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?'
     rdf_term: http://www.w3.org/2006/time#day
     rdf_type: xsd:gDay
@@ -142,15 +141,13 @@ properties:
   dayOfWeek:
     $ref: '#/$defs/DayOfWeek'
     default:
-    description: The day of week, whose value is a member of the class 
-      time:DayOfWeek
+    description: The day of week, whose value is a member of the class time:DayOfWeek
     rdf_term: http://www.w3.org/2006/time#dayOfWeek
     rdf_type: uri
   monthOfYear:
     $ref: '#/$defs/MonthOfYear'
     default:
-    description: The month of the year, whose value is a member of the class 
-      time:MonthOfYear
+    description: The month of the year, whose value is a member of the class time:MonthOfYear
     rdf_term: http://www.w3.org/2006/time#monthOfYear
     rdf_type: uri
 required:

--- a/models/time/GeneralDateTimeDescription.yaml
+++ b/models/time/GeneralDateTimeDescription.yaml
@@ -3,8 +3,8 @@ $namespace: http://www.w3.org/2006/time#
 $ontology: https://www.w3.org/TR/owl-time/
 $prefix: time
 additionalProperties: false
-description: Description of date and time structured with separate values for 
-  the various elements of a calendar-clock system
+description: Description of date and time structured with separate values for the
+  various elements of a calendar-clock system
 properties:
   timeZone:
     default:
@@ -16,8 +16,8 @@ properties:
     title: Timezone
     type: string
   unitType:
-    description: The temporal unit which provides the precision of a date-time 
-      value or scale of a temporal extent
+    description: The temporal unit which provides the precision of a date-time value
+      or scale of a temporal extent
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/2006/time#unitType
@@ -25,8 +25,8 @@ properties:
     title: Unittype
     type: string
   hasTRS:
-    description: The temporal reference system used by a temporal position or 
-      extent description
+    description: The temporal reference system used by a temporal position or extent
+      description
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -35,27 +35,27 @@ properties:
     type: string
   year:
     default:
-    description: Year position in a calendar-clock system. The range of this 
-      property is not specified, so can be replaced by any specific 
-      representation of a calendar year from any calendar.
+    description: Year position in a calendar-clock system. The range of this property
+      is not specified, so can be replaced by any specific representation of a calendar
+      year from any calendar.
     rdf_term: http://www.w3.org/2006/time#year
     rdf_type: xsd:gYear
     title: Year
     type: string
   month:
     default:
-    description: Month position in a calendar-clock system. The range of this 
-      property is not specified, so can be replaced by any specific 
-      representation of a calendar month from any calendar.
+    description: Month position in a calendar-clock system. The range of this property
+      is not specified, so can be replaced by any specific representation of a calendar
+      month from any calendar.
     rdf_term: http://www.w3.org/2006/time#month
     rdf_type: xsd:gMonth
     title: Month
     type: string
   day:
     default:
-    description: Day position in a calendar-clock system. The range of this 
-      property is not specified, so can be replaced by any specific 
-      representation of a calendar day from any calendar.
+    description: Day position in a calendar-clock system. The range of this property
+      is not specified, so can be replaced by any specific representation of a calendar
+      day from any calendar.
     rdf_term: http://www.w3.org/2006/time#day
     rdf_type: xsd:gDay
     title: Day
@@ -101,8 +101,7 @@ properties:
     type: integer
   dayOfWeek:
     default:
-    description: The day of week, whose value is a member of the class 
-      time:DayOfWeek
+    description: The day of week, whose value is a member of the class time:DayOfWeek
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -111,8 +110,7 @@ properties:
     type: string
   monthOfYear:
     default:
-    description: The month of the year, whose value is a member of the class 
-      time:MonthOfYear
+    description: The month of the year, whose value is a member of the class time:MonthOfYear
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/2006/time#monthOfYear

--- a/models/time/PeriodOfTime.yaml
+++ b/models/time/PeriodOfTime.yaml
@@ -6,8 +6,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -19,8 +19,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -28,8 +28,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -38,27 +38,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -104,8 +104,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -114,8 +113,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -132,7 +130,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -143,8 +141,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -179,8 +176,7 @@ $defs:
       inXSDDateTime:
         default:
         deprecated: true
-        description: (deprecated) Position of an instant, expressed using 
-          xsd:dateTime
+        description: (deprecated) Position of an instant, expressed using xsd:dateTime
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTime
         rdf_type: xsd:dateTime
@@ -188,8 +184,8 @@ $defs:
         type: string
       inXSDDateTimeStamp:
         default:
-        description: Position of an instant, expressed using xsd:dateTimeStamp, 
-          in which the time-zone field is mandatory
+        description: Position of an instant, expressed using xsd:dateTimeStamp, in
+          which the time-zone field is mandatory
         format: date-time
         rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
         rdf_type: xsd:dateTimeStamp
@@ -198,8 +194,7 @@ $defs:
       inXSDgYear:
         default:
         description: Position of an instant, expressed using xsd:gYear
-        pattern: 
-          -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+        pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
         rdf_term: http://www.w3.org/2006/time#inXSDgYear
         rdf_type: xsd:gYear
         title: Inxsdgyear
@@ -216,15 +211,14 @@ $defs:
       inTimePosition:
         $ref: '#/$defs/TimePosition'
         default:
-        description: Position of an instant, expressed as a temporal coordinate 
-          or nominal val
+        description: Position of an instant, expressed as a temporal coordinate or
+          nominal val
         rdf_term: http://www.w3.org/2006/time#inTimePosition
         rdf_type: http://www.w3.org/2006/time#TimePosition
       inDateTime:
         $ref: '#/$defs/GeneralDateTimeDescription'
         default:
-        description: Position of an instant, expressed using a structured 
-          description
+        description: Position of an instant, expressed using a structured description
         rdf_term: http://www.w3.org/2006/time#inDateTime
         rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
     title: TimeInstant
@@ -241,23 +235,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS

--- a/models/time/TimeInstant.yaml
+++ b/models/time/TimeInstant.yaml
@@ -6,8 +6,8 @@ $defs:
     $ontology: https://www.w3.org/TR/owl-time/
     $prefix: time
     additionalProperties: false
-    description: Description of date and time structured with separate values 
-      for the various elements of a calendar-clock system
+    description: Description of date and time structured with separate values for
+      the various elements of a calendar-clock system
     properties:
       timeZone:
         default:
@@ -19,8 +19,8 @@ $defs:
         title: Timezone
         type: string
       unitType:
-        description: The temporal unit which provides the precision of a 
-          date-time value or scale of a temporal extent
+        description: The temporal unit which provides the precision of a date-time
+          value or scale of a temporal extent
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#unitType
@@ -28,8 +28,8 @@ $defs:
         title: Unittype
         type: string
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -38,27 +38,27 @@ $defs:
         type: string
       year:
         default:
-        description: Year position in a calendar-clock system. The range of this
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar year from any calendar.
+        description: Year position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar year from any calendar.
         rdf_term: http://www.w3.org/2006/time#year
         rdf_type: xsd:gYear
         title: Year
         type: string
       month:
         default:
-        description: Month position in a calendar-clock system. The range of 
-          this property is not specified, so can be replaced by any specific 
-          representation of a calendar month from any calendar.
+        description: Month position in a calendar-clock system. The range of this
+          property is not specified, so can be replaced by any specific representation
+          of a calendar month from any calendar.
         rdf_term: http://www.w3.org/2006/time#month
         rdf_type: xsd:gMonth
         title: Month
         type: string
       day:
         default:
-        description: Day position in a calendar-clock system. The range of this 
-          property is not specified, so can be replaced by any specific 
-          representation of a calendar day from any calendar.
+        description: Day position in a calendar-clock system. The range of this property
+          is not specified, so can be replaced by any specific representation of a
+          calendar day from any calendar.
         rdf_term: http://www.w3.org/2006/time#day
         rdf_type: xsd:gDay
         title: Day
@@ -104,8 +104,7 @@ $defs:
         type: integer
       dayOfWeek:
         default:
-        description: The day of week, whose value is a member of the class 
-          time:DayOfWeek
+        description: The day of week, whose value is a member of the class time:DayOfWeek
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#dayOfWeek
@@ -114,8 +113,7 @@ $defs:
         type: string
       monthOfYear:
         default:
-        description: The month of the year, whose value is a member of the class
-          time:MonthOfYear
+        description: The month of the year, whose value is a member of the class time:MonthOfYear
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#monthOfYear
@@ -139,23 +137,23 @@ $defs:
     properties:
       nominalPosition:
         default:
-        description: The (nominal) value indicating temporal position in an 
-          ordinal reference system
+        description: The (nominal) value indicating temporal position in an ordinal
+          reference system
         rdf_term: http://www.w3.org/2006/time#nominalPosition
         rdf_type: xsd:string
         title: Nominalposition
         type: string
       numericPosition:
         default:
-        description: The (numeric) value indicating position within a temporal 
-          coordinate system
+        description: The (numeric) value indicating position within a temporal coordinate
+          system
         rdf_term: http://www.w3.org/2006/time#numericPosition
         rdf_type: xsd:decimal
         title: Numericposition
         type: number
       hasTRS:
-        description: The temporal reference system used by a temporal position 
-          or extent description
+        description: The temporal reference system used by a temporal position or
+          extent description
         format: uri
         minLength: 1
         rdf_term: http://www.w3.org/2006/time#hasTRS
@@ -183,8 +181,7 @@ properties:
   inXSDDateTime:
     default:
     deprecated: true
-    description: (deprecated) Position of an instant, expressed using 
-      xsd:dateTime
+    description: (deprecated) Position of an instant, expressed using xsd:dateTime
     format: date-time
     rdf_term: http://www.w3.org/2006/time#inXSDDateTime
     rdf_type: xsd:dateTime
@@ -192,8 +189,8 @@ properties:
     type: string
   inXSDDateTimeStamp:
     default:
-    description: Position of an instant, expressed using xsd:dateTimeStamp, in 
-      which the time-zone field is mandatory
+    description: Position of an instant, expressed using xsd:dateTimeStamp, in which
+      the time-zone field is mandatory
     format: date-time
     rdf_term: http://www.w3.org/2006/time#inXSDDateTimeStamp
     rdf_type: xsd:dateTimeStamp
@@ -202,8 +199,7 @@ properties:
   inXSDgYear:
     default:
     description: Position of an instant, expressed using xsd:gYear
-    pattern: 
-      -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
+    pattern: -?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?
     rdf_term: http://www.w3.org/2006/time#inXSDgYear
     rdf_type: xsd:gYear
     title: Inxsdgyear
@@ -220,15 +216,14 @@ properties:
   inTimePosition:
     $ref: '#/$defs/TimePosition'
     default:
-    description: Position of an instant, expressed as a temporal coordinate or 
-      nominal val
+    description: Position of an instant, expressed as a temporal coordinate or nominal
+      val
     rdf_term: http://www.w3.org/2006/time#inTimePosition
     rdf_type: http://www.w3.org/2006/time#TimePosition
   inDateTime:
     $ref: '#/$defs/GeneralDateTimeDescription'
     default:
-    description: Position of an instant, expressed using a structured 
-      description
+    description: Position of an instant, expressed using a structured description
     rdf_term: http://www.w3.org/2006/time#inDateTime
     rdf_type: http://www.w3.org/2006/time#GeneralDateTimeDescription
 title: TimeInstant

--- a/models/time/TimePosition.yaml
+++ b/models/time/TimePosition.yaml
@@ -8,23 +8,23 @@ description: "A temporal position described using either a (nominal) value from 
 properties:
   nominalPosition:
     default:
-    description: The (nominal) value indicating temporal position in an ordinal 
-      reference system
+    description: The (nominal) value indicating temporal position in an ordinal reference
+      system
     rdf_term: http://www.w3.org/2006/time#nominalPosition
     rdf_type: xsd:string
     title: Nominalposition
     type: string
   numericPosition:
     default:
-    description: The (numeric) value indicating position within a temporal 
-      coordinate system
+    description: The (numeric) value indicating position within a temporal coordinate
+      system
     rdf_term: http://www.w3.org/2006/time#numericPosition
     rdf_type: xsd:decimal
     title: Numericposition
     type: number
   hasTRS:
-    description: The temporal reference system used by a temporal position or 
-      extent description
+    description: The temporal reference system used by a temporal position or extent
+      description
     format: uri
     minLength: 1
     rdf_term: http://www.w3.org/2006/time#hasTRS

--- a/models/vcard/VCard.yaml
+++ b/models/vcard/VCard.yaml
@@ -5,7 +5,7 @@ $defs:
       : str, pydantic.AnyUrl Optional\n    datatype for literal value e.g. 'xsd:date'
       see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes\nlanguage : str Optional\n\
       \    RFC 3066 language tag, see https://datatracker.ietf.org/doc/html/rfc3066.html,
-      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n\
+      and also IANA-administrated \n    namespace of language tags: https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry\n
       value : str\n    literal value\neither datatype or language, or none of these
       two attributes should be provided \nas per http://www.w3.org/TR/rdf-concepts/#section-Graph-Literal"
     properties:
@@ -16,8 +16,7 @@ $defs:
           type: string
         - type: string
         default:
-        description: datatype,see 
-          https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
+        description: datatype,see https://www.w3.org/TR/xmlschema-2/#built-in-datatypes
         title: Datatype
       language:
         default:
@@ -53,8 +52,8 @@ properties:
     type: array
   formatted_name:
     default:
-    description: The full name of the object (as a single string). This is the 
-      only mandatory property.
+    description: The full name of the object (as a single string). This is the only
+      mandatory property.
     items:
       anyOf:
       - type: string

--- a/sempyro/dcat/dcat_distribution.py
+++ b/sempyro/dcat/dcat_distribution.py
@@ -150,7 +150,7 @@ class DCATDistribution(RDFModel):
         default=None,
         description="Minimum time period resolvable in the dataset.",
         json_schema_extra={
-            "rdf_term": DCAT.spatialResolutionInMeters,
+            "rdf_term": DCAT.temporalResolution,
             "rdf_type": "xsd:duration"
         }
     )

--- a/sempyro/healthdcatap/healthdcatap_distribution.py
+++ b/sempyro/healthdcatap/healthdcatap_distribution.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Union
+from typing import Union, List
 
 from pydantic import AnyHttpUrl, ConfigDict, Field
 from rdflib.namespace import DCAT
@@ -45,7 +45,7 @@ class HEALTHDCATAPDistribution(DCATDistribution):
             "rdf_type": "uri",
         },
     )
-    applicable_legislation: list[AnyHttpUrl] = Field(
+    applicable_legislation: List[AnyHttpUrl] = Field(
         description="The legislation that is applicable to this resource.",
         json_schema_extra={
             "rdf_term": DCATAPv3.applicableLegislation,


### PR DESCRIPTION
For DCAT Distribution the property 'temporal_resolution' wrongfully had the 'rdf_term' 'DCAT.spatialResolutionInMeters'.

For one of the HealthDCAT-AP properties 'list' was used instead of 'List'. Supporting the use of 'list' would require dropping support for Python 3.8. 