### PR TITLE
fix: remove obsolete comment

### DIFF
--- a/docs/Usage_example_GOE.ipynb
+++ b/docs/Usage_example_GOE.ipynb
@@ -217,13 +217,6 @@
     "\n",
     "print(distribution_fdp_id)\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note: Manually setting the `fdp_id` of the distribution into the dataset's distribution field is still required, as this has not been automated yet!\n"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Delete an obsolete markdown note from the GOE usage example Jupyter notebook.