### PR TITLE
fix: implement dependabot changes

### DIFF
--- a/.github/workflows/publish_package.yml
+++ b/.github/workflows/publish_package.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Build package
       run: hatch build
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: python-artifacts
         path: dist/*
@@ -56,7 +56,7 @@ jobs:
 
     steps:
         - name: Download Python artifacts
-          uses: actions/download-artifact@v7
+          uses: actions/download-artifact@v8
           with:
               name: python-artifacts
               path: dist


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub Actions workflow dependencies for publishing packages to use the latest artifact upload and download actions.

CI:
- Bump actions/upload-artifact from v6 to v7 in the publish_package workflow.
- Bump actions/download-artifact from v7 to v8 in the publish_package workflow.